### PR TITLE
[2.x] fix: cache subscribe fails on unix socket connections

### DIFF
--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -122,13 +122,11 @@ class CacheSubscribeCommand extends AbstractCommand
             $nodeConnection = $client->getConnection();
             $params = $nodeConnection->getParameters();
 
-            $pubsubClient = new \Predis\Client([
-                'scheme'             => $params->scheme ?? 'tcp',
-                'host'               => $params->host ?? 'localhost',
-                'port'               => $params->port ?? 6379,
-                'database'           => $params->database ?? 0,
-                'read_write_timeout' => 0, // Infinite timeout for pub/sub
-            ]);
+            // Use all original connection parameters (handles tcp, unix sockets, tls, etc.)
+            // and override read_write_timeout to 0 for the infinite blocking needed by pub/sub.
+            $pubsubClient = new \Predis\Client(
+                array_merge($params->toArray(), ['read_write_timeout' => 0])
+            );
 
             $this->subscribePredis($pubsubClient, $podId);
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
