### PR TITLE
[1.x] fix: cache subscribe fails on unix socket connections

### DIFF
--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -119,13 +119,9 @@ class CacheSubscribeCommand extends AbstractCommand
             // We need read_write_timeout = 0 for pub/sub to avoid timeouts while waiting for messages
             $params = $client->getConnection()->getParameters();
 
-            $pubsubClient = new \Predis\Client([
-                'scheme'             => $params->scheme ?? 'tcp',
-                'host'               => $params->host ?? 'localhost',
-                'port'               => $params->port ?? 6379,
-                'database'           => $params->database ?? 0,
-                'read_write_timeout' => 0, // Infinite timeout for pub/sub
-            ]);
+            $pubsubClient = new \Predis\Client(
+                array_merge($params->toArray(), ['read_write_timeout' => 0])
+            );
 
             $this->subscribePredis($pubsubClient, $podId);
 
@@ -333,14 +329,18 @@ class CacheSubscribeCommand extends AbstractCommand
      */
     private function isProcessRunning(int $pid): bool
     {
-        // Use posix_kill with signal 0 to check if process exists
-        // Signal 0 doesn't actually send a signal, just checks if we can
+        // /proc/$pid is readable regardless of process owner (Linux).
+        // posix_kill($pid, 0) returns false for cross-user processes when
+        // the caller lacks permission, causing false negatives.
+        if (file_exists("/proc/$pid")) {
+            return true;
+        }
+
+        // Fallback for non-Linux (macOS, BSD) where /proc is absent.
         if (function_exists('posix_kill')) {
             return posix_kill($pid, 0);
         }
 
-        // Fallback for systems without posix extension
-        // This works on Linux/Unix systems
-        return file_exists("/proc/$pid");
+        return false;
     }
 }

--- a/src/Provides/Cache.php
+++ b/src/Provides/Cache.php
@@ -218,11 +218,19 @@ class Cache extends Provider
 
     private function isProcessRunning(int $pid): bool
     {
+        // /proc/$pid is readable regardless of process owner (Linux).
+        // posix_kill($pid, 0) returns false for cross-user processes when
+        // the caller lacks permission, causing false negatives.
+        if (file_exists("/proc/$pid")) {
+            return true;
+        }
+
+        // Fallback for non-Linux (macOS, BSD) where /proc is absent.
         if (function_exists('posix_kill')) {
             return posix_kill($pid, 0);
         }
 
-        return file_exists("/proc/$pid");
+        return false;
     }
 
     private function acquireSpawnLock(string $lockFile, int $staleAfterSeconds): bool


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
