### PR TITLE
[2.x] fix: invalidate settings cache on extension enable/disable

### DIFF
--- a/src/Provides/Settings.php
+++ b/src/Provides/Settings.php
@@ -13,6 +13,8 @@
 
 namespace FoF\Redis\Provides;
 
+use Flarum\Extension\Event\Disabled;
+use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Settings\DatabaseSettingsRepository;
 use Flarum\Settings\DefaultSettingsRepository;
@@ -73,17 +75,25 @@ class Settings extends Provider
             );
         });
 
-        // Listen for cache clear events and clear settings cache too
-        $container->make(Dispatcher::class)->listen(
-            ClearingCache::class,
-            function () use ($container) {
-                try {
-                    $settingsCache = $container->make('cache.settings');
-                    $settingsCache->forget('flarum:settings');
-                } catch (\Exception $e) {
-                    // Fail gracefully if settings cache is unavailable
-                }
+        $invalidateSettingsCache = function () use ($container) {
+            try {
+                $settingsCache = $container->make('cache.settings');
+                $settingsCache->forget('flarum:settings');
+            } catch (\Exception $e) {
+                // Fail gracefully if settings cache is unavailable
             }
-        );
+        };
+
+        $dispatcher = $container->make(Dispatcher::class);
+
+        // Clear cached settings when the cache is explicitly cleared.
+        $dispatcher->listen(ClearingCache::class, $invalidateSettingsCache);
+
+        // Extension enable/disable writes extensions_enabled via MemoryCacheSettingsRepository
+        // (ExtensionManager is resolved before our binding override takes effect), so it bypasses
+        // RedisCacheSettingsRepository::set(). Invalidate the Redis key so the next read
+        // re-populates from DB, which always has the correct value.
+        $dispatcher->listen(Enabled::class, $invalidateSettingsCache);
+        $dispatcher->listen(Disabled::class, $invalidateSettingsCache);
     }
 }

--- a/src/Settings/RedisCacheSettingsRepository.php
+++ b/src/Settings/RedisCacheSettingsRepository.php
@@ -48,17 +48,30 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
     {
         $this->inner->set($key, $value);
 
-        // Invalidate entire cache to prevent race conditions in multi-container environments
-        // The cache will be rebuilt from database on next read
-        $this->cache->forget($this->cacheKey);
+        // Update the cache in-place to avoid a stale read-replica re-populating it.
+        // Environments with a read/write DB split (no `sticky` connection) would
+        // otherwise re-read the old value from the replica after forget().
+        // If the cache is cold, drop it entirely so the next all() re-builds from DB.
+        $all = $this->cache->get($this->cacheKey);
+
+        if (is_array($all)) {
+            $all[$key] = $value;
+            $this->cache->put($this->cacheKey, $all, $this->ttl);
+        }
     }
 
     public function delete(string $key): void
     {
         $this->inner->delete($key);
 
-        // Invalidate entire cache to prevent race conditions in multi-container environments
-        // The cache will be rebuilt from database on next read
-        $this->cache->forget($this->cacheKey);
+        // Remove the key from the cached array rather than dropping the whole entry,
+        // for the same reason as set(): avoids a stale replica re-read.
+        // If the cache is cold, there is nothing to patch.
+        $all = $this->cache->get($this->cacheKey);
+
+        if (is_array($all)) {
+            unset($all[$key]);
+            $this->cache->put($this->cacheKey, $all, $this->ttl);
+        }
     }
 }


### PR DESCRIPTION
## Problem

When `fof/redis`'s `Settings` provider overrides the `SettingsRepositoryInterface` binding, Flarum's `ExtensionManager` has **already been resolved as a singleton** — holding a reference to the original `MemoryCacheSettingsRepository`-backed instance. As a result, extension enable/disable operations call `MemoryCacheSettingsRepository::set()` directly, completely **bypassing `RedisCacheSettingsRepository::set()`**.

The `extensions_enabled` setting is written to the database correctly, but the Redis cache key (`flarum:settings`) is never updated and continues serving the stale value to every subsequent request. The extension appears to revert to its previous state on the next page load, even though the database is correct.

### Root cause confirmed via:
- **Redis MONITOR**: only `GET` commands observed during extension enable — no `SETEX`
- **Debug logging**: `RedisCacheSettingsRepository::set()` was never called
- **PHP reflection** on the live container: `ExtensionManager::$config` resolves to `DefaultSettingsRepository(MemoryCacheSettingsRepository)`, not the Redis-backed variant

## Fix

Listen to `Flarum\Extension\Event\Enabled` and `Flarum\Extension\Event\Disabled`, which fire **after** the database write has completed. On either event, invalidate the Redis `flarum:settings` cache key. The next `all()` call will re-populate from the database, which always reflects the correct post-write state.

A shared `$invalidateSettingsCache` closure is registered for all three events (`ClearingCache`, `Enabled`, `Disabled`) to avoid duplication.

## Additional improvement (`RedisCacheSettingsRepository`)

`set()` and `delete()` now patch the cached array **in-place** rather than calling `forget()`. This avoids a race window in environments with a read replica: if the cache is dropped and the next `remember()` runs before the replica has caught up with the write, the stale replica value would be re-cached. In-place patching keeps the cached snapshot consistent without a roundtrip.

## Testing

```bash
# Enable an extension — should remain enabled on next request
php flarum extension:enable ianm-follow-users

# Disable — should remain disabled
php flarum extension:disable ianm-follow-users
```

Confirmed via Redis MONITOR that `SETEX flarum:settings` is now issued after each `Enabled`/`Disabled` event, and that the admin panel reflects the correct state without a cache clear.