### PR TITLE
[1.x] fix: invalidate settings cache on extension enable/disable

### DIFF
--- a/src/Provides/Settings.php
+++ b/src/Provides/Settings.php
@@ -13,6 +13,8 @@
 
 namespace FoF\Redis\Provides;
 
+use Flarum\Extension\Event\Disabled;
+use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Settings\DatabaseSettingsRepository;
 use Flarum\Settings\DefaultSettingsRepository;
@@ -72,17 +74,25 @@ class Settings extends Provider
             );
         });
 
-        // Listen for cache clear events and clear settings cache too
-        $container->make(Dispatcher::class)->listen(
-            ClearingCache::class,
-            function () use ($container) {
-                try {
-                    $settingsCache = $container->make('cache.settings');
-                    $settingsCache->forget('flarum:settings');
-                } catch (\Exception $e) {
-                    // Fail gracefully if settings cache is unavailable
-                }
+        $invalidateSettingsCache = function () use ($container) {
+            try {
+                $settingsCache = $container->make('cache.settings');
+                $settingsCache->forget('flarum:settings');
+            } catch (\Exception $e) {
+                // Fail gracefully if settings cache is unavailable
             }
-        );
+        };
+
+        $dispatcher = $container->make(Dispatcher::class);
+
+        // Clear cached settings when the cache is explicitly cleared.
+        $dispatcher->listen(ClearingCache::class, $invalidateSettingsCache);
+
+        // Extension enable/disable writes extensions_enabled via MemoryCacheSettingsRepository
+        // (ExtensionManager is resolved before our binding override takes effect), so it bypasses
+        // RedisCacheSettingsRepository::set(). Invalidate the Redis key so the next read
+        // re-populates from DB, which always has the correct value.
+        $dispatcher->listen(Enabled::class, $invalidateSettingsCache);
+        $dispatcher->listen(Disabled::class, $invalidateSettingsCache);
     }
 }


### PR DESCRIPTION
## Problem

When `fof/redis`'s `Settings` provider overrides the `SettingsRepositoryInterface` binding, Flarum's `ExtensionManager` has **already been resolved as a singleton** — holding a reference to the original `MemoryCacheSettingsRepository`-backed instance. As a result, extension enable/disable operations call `MemoryCacheSettingsRepository::set()` directly, completely **bypassing `RedisCacheSettingsRepository::set()`**.

The `extensions_enabled` setting is written to the database correctly, but the Redis cache key (`flarum:settings`) is never updated and continues serving the stale value to every subsequent request. The extension appears to revert to its previous state on the next page load, even though the database is correct.

### Root cause confirmed via:
- **Redis MONITOR**: only `GET` commands observed during extension enable — no `SETEX`
- **Debug logging**: `RedisCacheSettingsRepository::set()` was never called
- **PHP reflection** on the live container: `ExtensionManager::$config` resolves to `DefaultSettingsRepository(MemoryCacheSettingsRepository)`, not the Redis-backed variant

## Fix

Listen to `Flarum\Extension\Event\Enabled` and `Flarum\Extension\Event\Disabled`, which fire **after** the database write has completed. On either event, invalidate the Redis `flarum:settings` cache key. The next `all()` call will re-populate from the database, which always reflects the correct post-write state.

A shared `$invalidateSettingsCache` closure is registered for all three events (`ClearingCache`, `Enabled`, `Disabled`) to avoid duplication.

## Testing

```bash
# Enable an extension — should remain enabled on next request
php flarum extension:enable ianm-follow-users

# Disable — should remain disabled
php flarum extension:disable ianm-follow-users
```

Confirmed (on 2.x) via Redis MONITOR that `SETEX flarum:settings` is now issued after each `Enabled`/`Disabled` event, and that the admin panel reflects the correct state without a cache clear.

Backport of #14 for the 1.x branch.