### PR TITLE
[2.x] fix: guard against re-entrant settings load causing infinite recursion

### DIFF
--- a/src/Settings/RedisCacheSettingsRepository.php
+++ b/src/Settings/RedisCacheSettingsRepository.php
@@ -23,6 +23,7 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
     protected CacheRepository $cache;
     protected string $cacheKey = 'flarum:settings';
     protected int $ttl = 3600; // 1 hour
+    protected bool $loading = false;
 
     public function __construct(SettingsRepositoryInterface $inner, CacheRepository $cache)
     {
@@ -32,9 +33,23 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
 
     public function all(): array
     {
-        return $this->cache->remember($this->cacheKey, $this->ttl, function () {
-            return $this->inner->all();
-        });
+        // Guard against re-entrant calls triggered by DB events fired during
+        // the cache-fill query (e.g. a subscriber that reads settings on
+        // StatementPrepared). Without this, the cache miss causes a DB query
+        // which fires an event which calls all() again → infinite recursion.
+        if ($this->loading) {
+            return [];
+        }
+
+        $this->loading = true;
+
+        try {
+            return $this->cache->remember($this->cacheKey, $this->ttl, function () {
+                return $this->inner->all();
+            });
+        } finally {
+            $this->loading = false;
+        }
     }
 
     public function get(string $key, mixed $default = null): mixed


### PR DESCRIPTION
## Summary

- When the settings cache is cold, `all()` issues a DB query to populate it
- If a DB event listener (e.g. `StatementPrepared`) reads settings during that query, it re-enters `all()` before the cache is populated
- This triggers another DB query → another event → another `all()` call → infinite recursion → stack overflow

The stack trace shows this pattern with `flarum-ext-rabbit-dispatcher`'s `RabbitEventSubscriber` listening on `StatementPrepared` and calling `Config::isEnabled()` → `SettingsRepository::get()`. Same root cause as #16 on `1.x`.

## Fix

Add a `$loading` boolean flag. Re-entrant calls return `[]` immediately without touching the DB, breaking the cycle. The outer `cache->remember()` completes normally and caches the real values.

## Test plan

- [ ] Save admin settings with both `fof/redis` and any extension that listens to DB events and reads settings installed — should no longer stack overflow
- [ ] Verify settings are correctly cached after the first cold load

🤖 Generated with [Claude Code](https://claude.com/claude-code)