### PR TITLE
[1.x] feat: auto-detect phpredis, fall back to Predis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,53 @@ return [
 
 This enables sessions, cache, settings, and queue to run on redis.
 
+#### phpredis vs Predis
+
+If the PHP `redis` extension (`ext-redis`) is installed, it will be used automatically. Otherwise Predis is used as a fallback. No configuration change is required.
+
+**Persistent connections (recommended for phpredis)**
+
+With phpredis, connections can be reused across requests within the same PHP-FPM worker process. Add `persistent` and `persistent_id` to your config to enable this:
+
+```php
+return [
+    new FoF\Redis\Extend\Redis([
+        'host'          => '127.0.0.1',
+        'password'      => null,
+        'port'          => 6379,
+        'database'      => 1,
+        'persistent'    => true,
+        'persistent_id' => 'flarum',  // groups connections into a named pool per worker
+    ])
+];
+```
+
+This avoids opening a new TCP connection on every request, which is a significant throughput improvement at scale. `persistent_id` is a string used to key the connection slot — use the same value across all workers on the same host.
+
+**Unix socket**
+
+```php
+return [
+    new FoF\Redis\Extend\Redis([
+        'host'          => '/var/run/redis/redis.sock',
+        'port'          => 0,
+        'database'      => 1,
+        'persistent'    => true,
+        'persistent_id' => 'flarum',
+    ])
+];
+```
+
+**Other phpredis options**
+
+| Key | Example | Notes |
+|---|---|---|
+| `timeout` | `2.0` | Connect timeout in seconds |
+| `read_timeout` | `2.0` | Per-command timeout |
+| `retry_interval` | `100` | ms between reconnect attempts |
+| `prefix` | `'flarum_'` | Key prefix |
+| `compression` | `Redis::COMPRESSION_LZ4` | phpredis ≥ 5.3, requires lz4/zstd compiled into ext-redis |
+
 > **Multi-instance deployments:** This extension can handle distributed cache invalidation across multiple Flarum instances (pods/containers) via Redis Pub/Sub. See [DISTRIBUTED_CACHE.md](DISTRIBUTED_CACHE.md) for details.
 
 #### Settings Cache

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     },
     "require-dev": {
         "flarum/phpstan": "*",
-        "flarum/testing": "*"
+        "flarum/testing": "*",
+        "jetbrains/phpstorm-stubs": "^2025.3"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -107,23 +107,23 @@ class CacheSubscribeCommand extends AbstractCommand
             $connection = $redis->connection('fof.cache');
             $client = $connection->client();
 
-            // Verify we have a Predis client (fof/redis always uses Predis)
-            if (!$client instanceof \Predis\Client) {
-                $this->error('[Cache Subscriber] Expected Predis client, got: '.get_class($client));
-                $this->logger->error('[Cache Subscriber] Unexpected Redis client type', ['client' => get_class($client)]);
+            if ($client instanceof \Redis) {
+                // phpredis: set infinite read timeout so pub/sub never times out waiting for messages
+                $client->setOption(\Redis::OPT_READ_TIMEOUT, -1);
+                $this->subscribePhpRedis($client, $podId);
+            } elseif ($client instanceof \Predis\Client) {
+                // Predis: create a new client with read_write_timeout=0 for the same reason
+                $params = $client->getConnection()->getParameters();
+                $pubsubClient = new \Predis\Client(
+                    array_merge($params->toArray(), ['read_write_timeout' => 0])
+                );
+                $this->subscribePredis($pubsubClient, $podId);
+            } else {
+                $this->error('[Cache Subscriber] Unsupported Redis client: '.get_class($client));
+                $this->logger->error('[Cache Subscriber] Unsupported Redis client type', ['client' => get_class($client)]);
 
                 return 1;
             }
-
-            // Get connection parameters and create new client with infinite timeout
-            // We need read_write_timeout = 0 for pub/sub to avoid timeouts while waiting for messages
-            $params = $client->getConnection()->getParameters();
-
-            $pubsubClient = new \Predis\Client(
-                array_merge($params->toArray(), ['read_write_timeout' => 0])
-            );
-
-            $this->subscribePredis($pubsubClient, $podId);
 
             // If we reach here, subscription ended (connection died)
             $this->removeLockFile();
@@ -181,6 +181,40 @@ class CacheSubscribeCommand extends AbstractCommand
             ]);
 
             throw $e;
+        }
+    }
+
+    /**
+     * Subscribe using phpredis client.
+     *
+     * phpredis subscribe() is blocking and invokes the callback for each message.
+     * To support --once, we throw a sentinel exception from the callback and catch it here.
+     */
+    private function subscribePhpRedis(\Redis $client, string $podId): void
+    {
+        $channel = (string) $this->input->getOption('channel');
+
+        $this->info('[Cache Subscriber] ✓ Connected (phpredis)');
+        $this->logger->info('[Cache Subscriber] Connected', ['client' => 'phpredis', 'pod' => $podId]);
+
+        $this->info("[Cache Subscriber] ✓ Subscribed to channel: {$channel}");
+        $this->logger->info('[Cache Subscriber] Subscribed successfully', ['pod' => $podId, 'channel' => $channel]);
+        $this->info("[Cache Subscriber] Running on pod: {$podId}");
+        $this->logger->info('[Cache Subscriber] Running', ['pod' => $podId]);
+
+        try {
+            $client->subscribe([$channel], function (\Redis $redis, string $chan, string $payload) use ($podId) {
+                $shouldExit = $this->handleMessage($payload, $podId);
+
+                if ($shouldExit) {
+                    // phpredis has no clean unsubscribe from within the callback;
+                    // closing the connection is the standard approach.
+                    $redis->close();
+                }
+            });
+        } catch (\Exception $e) {
+            // A closed connection throws; if it was intentional (--once) that's fine.
+            $this->logger->info('[Cache Subscriber] Subscription ended', ['pod' => $podId, 'reason' => $e->getMessage()]);
         }
     }
 

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -203,9 +203,6 @@ class CacheSubscribeCommand extends AbstractCommand
         $this->logger->info('[Cache Subscriber] Running', ['pod' => $podId]);
 
         try {
-            // phpredis 6.x subscribe() accepts a Closure as second argument at runtime,
-            // but older PHPStan stubs incorrectly type it as array|string.
-            // @phpstan-ignore-next-line
             $client->subscribe([$channel], function (\Redis $redis, string $chan, string $payload) use ($podId) {
                 $shouldExit = $this->handleMessage($payload, $podId);
 

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -203,6 +203,9 @@ class CacheSubscribeCommand extends AbstractCommand
         $this->logger->info('[Cache Subscriber] Running', ['pod' => $podId]);
 
         try {
+            // phpredis 6.x subscribe() accepts a Closure as second argument at runtime,
+            // but older PHPStan stubs incorrectly type it as array|string.
+            // @phpstan-ignore-next-line
             $client->subscribe([$channel], function (\Redis $redis, string $chan, string $payload) use ($podId) {
                 $shouldExit = $this->handleMessage($payload, $podId);
 

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -203,6 +203,8 @@ class CacheSubscribeCommand extends AbstractCommand
         $this->logger->info('[Cache Subscriber] Running', ['pod' => $podId]);
 
         try {
+            // phpredis subscribe() accepts a callable at runtime; PHPStan stubs incorrectly type it as array|string.
+            // @phpstan-ignore-next-line
             $client->subscribe([$channel], function (\Redis $redis, string $chan, string $payload) use ($podId) {
                 $shouldExit = $this->handleMessage($payload, $podId);
 

--- a/src/Extend/Bindings.php
+++ b/src/Extend/Bindings.php
@@ -25,7 +25,9 @@ class Bindings implements ExtenderInterface
     {
         if (!$container->has(RedisManager::class)) {
             $container->singleton(RedisManager::class, function ($app) {
-                return new RedisManager($app, 'predis', []);
+                $driver = extension_loaded('redis') ? 'phpredis' : 'predis';
+
+                return new RedisManager($app, $driver, []);
             });
 
             $container->alias(RedisManager::class, Factory::class);


### PR DESCRIPTION
## Summary

- If `ext-redis` (phpredis) is installed, it is used as the Redis driver automatically. Otherwise Predis is used as a fallback.
- No configuration change required by consumers — the driver is selected at runtime.
- Documents persistent connections (`persistent`, `persistent_id`), Unix socket connections, and compression options in the README.

## Why

Predis opens a new TCP connection per request. phpredis supports persistent connections, reusing the socket across requests within the same PHP-FPM worker. At scale this significantly reduces connection overhead and Valkey/Redis network bandwidth consumption.

## Test plan

- [ ] Verify with `ext-redis` loaded: driver resolves to `phpredis`
- [ ] Verify without `ext-redis`: driver falls back to `predis`
- [ ] Confirm persistent connections work with `persistent: true` + `persistent_id`
- [ ] Confirm Unix socket connections work with `host: /path/to/redis.sock`, `port: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)