### PR TITLE
[2.x] feat: phpredis auto-detect, cache:subscribe fix, settings memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,53 @@ return [
 
 This enables sessions, cache, settings, and queue to run on redis.
 
+#### phpredis vs Predis
+
+If the PHP `redis` extension (`ext-redis`) is installed, it will be used automatically. Otherwise Predis is used as a fallback. No configuration change is required.
+
+**Persistent connections (recommended for phpredis)**
+
+With phpredis, connections can be reused across requests within the same PHP-FPM worker process. Add `persistent` and `persistent_id` to your config to enable this:
+
+```php
+return [
+    new FoF\Redis\Extend\Redis([
+        'host'          => '127.0.0.1',
+        'password'      => null,
+        'port'          => 6379,
+        'database'      => 1,
+        'persistent'    => true,
+        'persistent_id' => 'flarum',  // groups connections into a named pool per worker
+    ])
+];
+```
+
+This avoids opening a new TCP connection on every request, which is a significant throughput improvement at scale. `persistent_id` is a string used to key the connection slot — use the same value across all workers on the same host.
+
+**Unix socket**
+
+```php
+return [
+    new FoF\Redis\Extend\Redis([
+        'host'          => '/var/run/redis/redis.sock',
+        'port'          => 0,
+        'database'      => 1,
+        'persistent'    => true,
+        'persistent_id' => 'flarum',
+    ])
+];
+```
+
+**Other phpredis options**
+
+| Key | Example | Notes |
+|---|---|---|
+| `timeout` | `2.0` | Connect timeout in seconds |
+| `read_timeout` | `2.0` | Per-command timeout |
+| `retry_interval` | `100` | ms between reconnect attempts |
+| `prefix` | `'flarum_'` | Key prefix |
+| `compression` | `Redis::COMPRESSION_LZ4` | phpredis ≥ 5.3, requires lz4/zstd compiled into ext-redis |
+
 > **Multi-instance deployments:** This extension can handle distributed cache invalidation across multiple Flarum instances (pods/containers) via Redis Pub/Sub. See [DISTRIBUTED_CACHE.md](DISTRIBUTED_CACHE.md) for details.
 
 #### Settings Cache

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -108,27 +108,26 @@ class CacheSubscribeCommand extends AbstractCommand
             $connection = $redis->connection('fof.cache');
             $client = $connection->client();
 
-            // Verify we have a Predis client (fof/redis always uses Predis)
-            if (!$client instanceof \Predis\Client) {
-                $this->error('[Cache Subscriber] Expected Predis client, got: '.get_class($client));
-                $this->logger->error('[Cache Subscriber] Unexpected Redis client type', ['client' => get_class($client)]);
+            if ($client instanceof \Redis) {
+                // phpredis: set infinite read timeout so pub/sub never times out waiting for messages
+                $client->setOption(\Redis::OPT_READ_TIMEOUT, -1);
+                $this->subscribePhpRedis($client, $podId);
+            } elseif ($client instanceof \Predis\Client) {
+                // Predis: create a new client with read_write_timeout=0 for the same reason
+                // Use all original connection parameters (handles tcp, unix sockets, tls, etc.)
+                /** @var NodeConnectionInterface $nodeConnection */
+                $nodeConnection = $client->getConnection();
+                $params = $nodeConnection->getParameters();
+                $pubsubClient = new \Predis\Client(
+                    array_merge($params->toArray(), ['read_write_timeout' => 0])
+                );
+                $this->subscribePredis($pubsubClient, $podId);
+            } else {
+                $this->error('[Cache Subscriber] Unsupported Redis client: '.get_class($client));
+                $this->logger->error('[Cache Subscriber] Unsupported Redis client type', ['client' => get_class($client)]);
 
                 return 1;
             }
-
-            // Get connection parameters and create new client with infinite timeout
-            // We need read_write_timeout = 0 for pub/sub to avoid timeouts while waiting for messages
-            /** @var NodeConnectionInterface $nodeConnection */
-            $nodeConnection = $client->getConnection();
-            $params = $nodeConnection->getParameters();
-
-            // Use all original connection parameters (handles tcp, unix sockets, tls, etc.)
-            // and override read_write_timeout to 0 for the infinite blocking needed by pub/sub.
-            $pubsubClient = new \Predis\Client(
-                array_merge($params->toArray(), ['read_write_timeout' => 0])
-            );
-
-            $this->subscribePredis($pubsubClient, $podId);
 
             // If we reach here, subscription ended (connection died)
             $this->removeLockFile();
@@ -187,6 +186,40 @@ class CacheSubscribeCommand extends AbstractCommand
             ]);
 
             throw $e;
+        }
+    }
+
+    /**
+     * Subscribe using phpredis client.
+     *
+     * phpredis subscribe() is blocking and invokes the callback for each message.
+     * To support --once, we close the connection from within the callback.
+     */
+    private function subscribePhpRedis(\Redis $client, string $podId): void
+    {
+        $channel = (string) $this->input->getOption('channel');
+
+        $this->info('[Cache Subscriber] ✓ Connected (phpredis)');
+        $this->logger->info('[Cache Subscriber] Connected', ['client' => 'phpredis', 'pod' => $podId]);
+
+        $this->info("[Cache Subscriber] ✓ Subscribed to channel: {$channel}");
+        $this->logger->info('[Cache Subscriber] Subscribed successfully', ['pod' => $podId, 'channel' => $channel]);
+        $this->info("[Cache Subscriber] Running on pod: {$podId}");
+        $this->logger->info('[Cache Subscriber] Running', ['pod' => $podId]);
+
+        try {
+            $client->subscribe([$channel], function (\Redis $redis, string $chan, string $payload) use ($podId) {
+                $shouldExit = $this->handleMessage($payload, $podId);
+
+                if ($shouldExit) {
+                    // phpredis has no clean unsubscribe from within the callback;
+                    // closing the connection is the standard approach.
+                    $redis->close();
+                }
+            });
+        } catch (\Exception $e) {
+            // A closed connection throws; if it was intentional (--once) that's fine.
+            $this->logger->info('[Cache Subscriber] Subscription ended', ['pod' => $podId, 'reason' => $e->getMessage()]);
         }
     }
 

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -208,6 +208,9 @@ class CacheSubscribeCommand extends AbstractCommand
         $this->logger->info('[Cache Subscriber] Running', ['pod' => $podId]);
 
         try {
+            // phpredis 6.x subscribe() accepts a Closure as second argument at runtime,
+            // but older PHPStan stubs incorrectly type it as array|string.
+            // @phpstan-ignore-next-line
             $client->subscribe([$channel], function (\Redis $redis, string $chan, string $payload) use ($podId) {
                 $shouldExit = $this->handleMessage($payload, $podId);
 

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -208,9 +208,6 @@ class CacheSubscribeCommand extends AbstractCommand
         $this->logger->info('[Cache Subscriber] Running', ['pod' => $podId]);
 
         try {
-            // phpredis 6.x subscribe() accepts a Closure as second argument at runtime,
-            // but older PHPStan stubs incorrectly type it as array|string.
-            // @phpstan-ignore-next-line
             $client->subscribe([$channel], function (\Redis $redis, string $chan, string $payload) use ($podId) {
                 $shouldExit = $this->handleMessage($payload, $podId);
 

--- a/src/Extend/Bindings.php
+++ b/src/Extend/Bindings.php
@@ -26,7 +26,9 @@ class Bindings implements ExtenderInterface
     {
         if (!$container->has(RedisManager::class)) {
             $container->singleton(RedisManager::class, function ($app) {
-                return new RedisManager($app, 'predis', []);
+                $driver = extension_loaded('redis') ? 'phpredis' : 'predis';
+
+                return new RedisManager($app, $driver, []);
             });
 
             $container->alias(RedisManager::class, Factory::class);

--- a/src/Provides/Settings.php
+++ b/src/Provides/Settings.php
@@ -18,6 +18,7 @@ use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Settings\DatabaseSettingsRepository;
 use Flarum\Settings\DefaultSettingsRepository;
+use Flarum\Settings\MemoryCacheSettingsRepository;
 use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Redis\Configuration;
 use FoF\Redis\Overrides\RedisManager;
@@ -60,16 +61,21 @@ class Settings extends Provider
             return new Repository($store);
         });
 
-        // Replace the entire settings repository binding to use Redis caching instead of MemoryCache
+        // Replace the entire settings repository binding with a three-layer chain:
+        // MemoryCacheSettingsRepository  — per-request in-process cache (zero network cost after first read)
+        //   └── RedisCacheSettingsRepository  — cross-request Redis cache (one Redis GET per request, 1h TTL)
+        //         └── DatabaseSettingsRepository  — source of truth (MySQL, hit only on Redis miss)
         $container->singleton(SettingsRepositoryInterface::class, function (Container $container) {
             $cache = $container->make('cache.settings');
 
             return new DefaultSettingsRepository(
-                new RedisCacheSettingsRepository(
-                    new DatabaseSettingsRepository(
-                        $container->make(ConnectionInterface::class)
-                    ),
-                    $cache
+                new MemoryCacheSettingsRepository(
+                    new RedisCacheSettingsRepository(
+                        new DatabaseSettingsRepository(
+                            $container->make(ConnectionInterface::class)
+                        ),
+                        $cache
+                    )
                 ),
                 $container->make('flarum.settings.default')
             );


### PR DESCRIPTION
## Changes

### 1. Auto-detect phpredis, fall back to Predis

Detects the available Redis client at runtime rather than assuming Predis. If the `phpredis` extension is loaded, it is used directly; otherwise falls back to Predis. No configuration change required.

### 2. Fix `cache:subscribe` with phpredis

The `cache:subscribe` command was hardcoded to check `instanceof \Predis\Client`, causing it to abort immediately when phpredis is active. Replaced with driver-agnostic routing:

- **phpredis**: uses callback-based `subscribe()` with `OPT_READ_TIMEOUT = -1` and `$redis->close()` to exit on `--once`
- **Predis**: existing pub/sub loop preserved, creates a new client with `read_write_timeout: 0`

### 3. Add `MemoryCacheSettingsRepository` layer to eliminate per-call Redis fetches

`RedisCacheSettingsRepository::get()` calls `all()` on every invocation, which calls `cache->remember()` every time — a Redis `GET` of the full `flarum:settings` blob on each call.

On a typical forum page, settings are read 60–100 times (core serializers, frontend JS variable injection, middleware, extensions). Each call fetches the entire settings blob from Redis — on production this is **~154 KB**. That's up to **~15 MB of Redis egress per page load** from settings reads alone, which at scale accounts for the majority of observed Redis outbound bandwidth (~300 Mbps on Nothing Community).

Flarum core's `SettingsServiceProvider` uses `MemoryCacheSettingsRepository` to provide a per-request in-process cache. `fof/redis`'s `Settings` provider replaced the entire binding without restoring this layer.

The fix wraps `RedisCacheSettingsRepository` with `MemoryCacheSettingsRepository`, restoring the three-layer chain:

```
MemoryCacheSettingsRepository   ← per-request in-process cache (zero network cost after first read)
  └── RedisCacheSettingsRepository  ← cross-request Redis cache (one Redis GET per request, 1h TTL)
        └── DatabaseSettingsRepository  ← source of truth (MySQL, hit only on Redis miss)
```

After this change, Redis is hit **at most once per request** for settings instead of once per `settings->get()` call. Expected Redis egress reduction: ~95%+ of settings-related bandwidth eliminated.