### PR TITLE
chore: upgrade to Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "flarum/core": "^2.0.0",
-        "illuminate/redis": "^11.0 || ^12.0",
+        "illuminate/redis": "^13.0",
         "predis/predis": "^v2.3.0"
     },
     "autoload": {

--- a/src/Settings/RedisCacheSettingsRepository.php
+++ b/src/Settings/RedisCacheSettingsRepository.php
@@ -44,7 +44,7 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
         $this->loading = true;
 
         try {
-            return $this->cache->remember($this->cacheKey, $this->ttl, function () {
+            return $this->cache->flexible($this->cacheKey, [$this->ttl - 300, $this->ttl], function () {
                 return $this->inner->all();
             });
         } finally {


### PR DESCRIPTION
## Summary

#### CI will fail until core is next released

- Bumps \`illuminate/redis\` from \`^11.0 || ^12.0\` to \`^13.0\`
- Replaces \`Cache::remember\` with \`Cache::flexible\` in \`RedisCacheSettingsRepository\` — serves stale settings for the final 5 minutes of the 1-hour TTL while one background process refreshes, eliminating the expiry stampede

## Related

- flarum/framework: https://github.com/flarum/framework/pull/4468
- fof/horizon: https://github.com/FriendsOfFlarum/horizon/pull/23