### PR TITLE
[2.x] chore: Add backend tests; fix PUBSUB NUMSUB across phpredis and predis

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,7 +6,16 @@ jobs:
   run:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@2.x
     with:
-      enable_backend_testing: false
+      enable_backend_testing: true
       enable_phpstan: true
 
       backend_directory: .
+
+      # Run a Redis-compatible service for the integration tests, and exercise
+      # BOTH supported client libraries: 'phpredis' (native extension) and
+      # 'predis' (pure PHP). fof/redis auto-detects the client at runtime, and
+      # the two disagree on some command signatures (e.g. PUBSUB NUMSUB), so
+      # both must be covered.
+      enable_redis: true
+      redis_variant: valkey
+      redis_clients: '["phpredis", "predis"]'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 js/node_modules
 vendor/
 composer.lock
+
+tests/.phpunit.cache
+tests/.phpunit.result.cache
+/tests/integration/tmp

--- a/composer.json
+++ b/composer.json
@@ -38,14 +38,28 @@
             "FoF\\Redis\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "FoF\\Redis\\Tests\\": "tests/"
+        }
+    },
     "require-dev": {
-        "flarum/phpstan": "2.x-dev"
+        "flarum/phpstan": "2.x-dev",
+        "flarum/testing": "^2.0.0"
     },
     "scripts": {
+        "test": [
+            "@test:integration"
+        ],
+        "test:integration": "phpunit -c tests/phpunit.integration.xml",
+        "test:setup": "@php tests/integration/setup.php",
         "analyse:phpstan": "phpstan analyse",
         "clear-cache:phpstan": "phpstan clear-result-cache"
     },
     "scripts-descriptions": {
+        "test": "Runs all tests.",
+        "test:integration": "Runs all integration tests.",
+        "test:setup": "Sets up a database for use with integration tests. Execute this only once.",
         "analyse:phpstan": "Run static analysis"
     },
     "minimum-stability": "dev",

--- a/src/Console/RedisInfoCommand.php
+++ b/src/Console/RedisInfoCommand.php
@@ -82,14 +82,31 @@ class RedisInfoCommand extends AbstractCommand
         try {
             /** @var RedisManager $manager */
             $manager = resolve(RedisManager::class);
-            $result = $manager->connection('fof.cache')->command('pubsub', ['numsub', $channel]);
+            $client = $manager->connection('fof.cache')->client();
 
-            /** @var array<string, int> $numsub */
-            $numsub = $result;
+            // PUBSUB NUMSUB channel-list. The two supported clients disagree on
+            // how the channel argument must be passed and reject the other's
+            // form: phpredis (\Redis) wants the channels as an array and errors
+            // on a bare string ("Invalid channels value"); predis wants a
+            // string and mangles an array ("Array to string conversion").
+            // Branch on the client so each gets the form it accepts. Both then
+            // return an associative [channel => count] map.
+            if ($client instanceof \Redis) {
+                /** @var array<string, int> $numsub */
+                $numsub = $client->pubsub('numsub', [$channel]);
+            } elseif ($client instanceof \Predis\Client) {
+                /** @var array<string, int> $numsub */
+                $numsub = $client->pubsub('numsub', $channel);
+            } else {
+                $this->output->writeln('<comment>Pub/sub subscriber count unavailable: unsupported Redis client '.get_class($client).'</comment>');
+
+                return;
+            }
+
             $count = $numsub[$channel] ?? 0;
 
             $this->output->writeln('<info>Pub/sub subscribers:</info> '.$count);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->output->writeln('<comment>Pub/sub subscriber count unavailable: '.$e->getMessage().'</comment>');
         }
     }

--- a/tests/integration/RedisInfoCommandTest.php
+++ b/tests/integration/RedisInfoCommandTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use FoF\Redis\Extend\Redis;
+use PHPUnit\Framework\Attributes\Test;
+
+class RedisInfoCommandTest extends ConsoleTestCase
+{
+    use RedisTestConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extend(
+            (new Redis($this->redisConfig()))
+                ->useDatabaseWith('cache', 1)
+                ->useDatabaseWith('queue', 2)
+                ->useDatabaseWith('session', 3)
+        );
+    }
+
+    #[Test]
+    public function it_reports_the_configured_redis_services()
+    {
+        $output = $this->runCommand(['command' => 'redis:info']);
+
+        $this->assertStringContainsString('Redis services:', $output);
+        $this->assertStringContainsString('cache', $output);
+        $this->assertStringContainsString('queue', $output);
+        $this->assertStringContainsString('session', $output);
+    }
+
+    #[Test]
+    public function it_reports_the_pubsub_channel()
+    {
+        $output = $this->runCommand(['command' => 'redis:info']);
+
+        $this->assertStringContainsString('Pub/sub enabled:', $output);
+        $this->assertStringContainsString('Pub/sub channel:', $output);
+    }
+
+    /**
+     * Regression test for the PUBSUB NUMSUB subscriber-count line.
+     *
+     * phpredis and predis disagree on how the channel argument must be passed:
+     * phpredis (\Redis) wants an array and errors with a PHP warning on a bare
+     * string ("Invalid channels value"); predis wants a string and mangles an
+     * array ("Array to string conversion"). The buggy single-client form
+     * therefore breaks on whichever client the command was NOT written for.
+     *
+     * Crucially, on a fresh server there are zero subscribers, so a broken
+     * count and a correct count both print "0" — the count value alone can't
+     * distinguish the fix from the bug. The reliable signal is the PHP
+     * warning, so this test converts any PHP warning raised during the command
+     * into a test failure. It runs under both clients via the CI matrix, so it
+     * fails on whichever client the command gets wrong.
+     */
+    #[Test]
+    public function it_reports_the_pubsub_subscriber_count_without_raising_a_warning()
+    {
+        $warnings = [];
+
+        set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = $errstr;
+
+            return true; // swallow so it doesn't abort; we assert on it below
+        }, E_WARNING | E_NOTICE | E_USER_WARNING | E_DEPRECATED);
+
+        try {
+            $output = $this->runCommand(['command' => 'redis:info']);
+        } finally {
+            restore_error_handler();
+        }
+
+        // No PHP warning may be raised while counting subscribers. This is what
+        // fails on the buggy single-client code under the "wrong" client.
+        $clientWarnings = array_filter(
+            $warnings,
+            fn (string $w) => str_contains($w, 'Invalid channels value')
+                || str_contains($w, 'Array to string conversion')
+                || str_contains($w, 'pubsub')
+        );
+        $this->assertSame(
+            [],
+            array_values($clientWarnings),
+            'redis:info raised a client-specific PUBSUB warning: '.implode('; ', $clientWarnings)
+        );
+
+        // And the count line must still be present as a plain integer.
+        $this->assertMatchesRegularExpression(
+            '/Pub\/sub subscribers:\s+\d+/',
+            $output,
+            'redis:info should report a numeric subscriber count'
+        );
+        $this->assertStringNotContainsString('subscriber count unavailable', $output);
+    }
+
+    /**
+     * With exactly one live subscriber on the channel, the reported count must
+     * be at least 1 — proving the command reads NUMSUB correctly (right client
+     * call AND right result shape), not merely that it avoids a warning. A
+     * background PHP process holds the subscription for the duration.
+     *
+     * We assert ">= 1" rather than "== 1" because a shared Redis (e.g. a dev
+     * box, or parallel CI on one server) may have other subscribers; the point
+     * is that OUR subscriber is counted, which a broken NUMSUB read (returning
+     * 0/false) would miss.
+     */
+    #[Test]
+    public function it_counts_a_live_subscriber()
+    {
+        $config = $this->redisConfig();
+        $channel = 'flarum:cache:invalidate';
+
+        $subscriber = $this->spawnSubscriber($config['host'], (int) $config['port'], $channel);
+
+        try {
+            // Give the background subscriber a moment to establish before we count.
+            $this->waitForSubscriber($config, $channel);
+
+            $output = $this->runCommand(['command' => 'redis:info']);
+        } finally {
+            $this->stopSubscriber($subscriber);
+        }
+
+        preg_match('/Pub\/sub subscribers:\s+(\d+)/', $output, $m);
+        $this->assertNotEmpty($m, "redis:info did not report a subscriber count:\n$output");
+        $this->assertGreaterThanOrEqual(
+            1,
+            (int) $m[1],
+            'redis:info should count the live subscriber, got '.$m[1]
+        );
+    }
+
+    /**
+     * Spawn a detached PHP process that subscribes to the channel and blocks.
+     * Returns the proc-open resource + pipes for teardown.
+     *
+     * @return array{0: resource, 1: array}
+     */
+    private function spawnSubscriber(string $host, int $port, string $channel): array
+    {
+        // Match the extender's client selection so we exercise the same stack.
+        if (extension_loaded('redis')) {
+            $code = sprintf(
+                '$r=new Redis();$r->connect(%s,%d);$r->setOption(Redis::OPT_READ_TIMEOUT,-1);'
+                .'$r->subscribe([%s],function(){});',
+                var_export($host, true),
+                $port,
+                var_export($channel, true)
+            );
+        } else {
+            $code = sprintf(
+                'require %s;$c=new Predis\Client(["scheme"=>"tcp","host"=>%s,"port"=>%d,"read_write_timeout"=>0]);'
+                .'$ps=$c->pubSubLoop();$ps->subscribe(%s);foreach($ps as $m){}',
+                var_export(getcwd().'/vendor/autoload.php', true),
+                var_export($host, true),
+                $port,
+                var_export($channel, true)
+            );
+        }
+
+        $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $proc = proc_open([PHP_BINARY, '-r', $code], $descriptors, $pipes);
+
+        $this->assertIsResource($proc, 'failed to spawn subscriber process');
+
+        return [$proc, $pipes];
+    }
+
+    /**
+     * Poll NUMSUB directly until our subscriber appears (or time out).
+     */
+    private function waitForSubscriber(array $config, string $channel): void
+    {
+        $deadline = microtime(true) + 5.0;
+
+        while (microtime(true) < $deadline) {
+            if (extension_loaded('redis')) {
+                $r = new \Redis();
+                $r->connect($config['host'], (int) $config['port']);
+                $res = $r->pubsub('numsub', [$channel]);
+                $r->close();
+            } else {
+                $c = new \Predis\Client(['scheme' => 'tcp', 'host' => $config['host'], 'port' => (int) $config['port']]);
+                $res = $c->pubsub('numsub', $channel);
+            }
+
+            if ((int) ($res[$channel] ?? 0) >= 1) {
+                return;
+            }
+
+            usleep(100_000);
+        }
+
+        $this->fail('background subscriber never registered on the channel');
+    }
+
+    /**
+     * @param array{0: resource, 1: array} $subscriber
+     */
+    private function stopSubscriber(array $subscriber): void
+    {
+        [$proc, $pipes] = $subscriber;
+
+        foreach ($pipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+
+        if (is_resource($proc)) {
+            proc_terminate($proc, SIGKILL);
+            proc_close($proc);
+        }
+    }
+}

--- a/tests/integration/RedisTestConfig.php
+++ b/tests/integration/RedisTestConfig.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+/**
+ * Shared Redis connection config for integration tests.
+ *
+ * Points at a Redis-compatible server on 127.0.0.1:6379 by default, which is
+ * exactly what the reusable backend CI workflow exposes when `enable_redis`
+ * is set. Overridable via REDIS_HOST / REDIS_PORT for local runs.
+ */
+trait RedisTestConfig
+{
+    protected function redisConfig(): array
+    {
+        return [
+            'host'        => getenv('REDIS_HOST') ?: '127.0.0.1',
+            'password'    => null,
+            'port'        => (int) (getenv('REDIS_PORT') ?: 6379),
+            'database'    => 1,
+            'prefix'      => '',
+            'pubsub'      => [
+                'enabled'   => true,
+                'autostart' => false,
+            ],
+            'persistent' => false,
+        ];
+    }
+}

--- a/tests/integration/setup.php
+++ b/tests/integration/setup.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Testing\integration\Setup\SetupScript;
+
+require __DIR__.'/../../vendor/autoload.php';
+
+$setup = new SetupScript();
+
+$setup->run();

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
+    colors="true"
+    processIsolation="true"
+    stopOnFailure="false"
+>
+    <source>
+        <include>
+            <directory suffix=".php">../src/</directory>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="Flarum Integration Tests">
+            <directory suffix="Test.php">./integration</directory>
+            <exclude>./integration/tmp</exclude>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## The bug

`redis:info`'s subscriber-count line read `PUBSUB NUMSUB` with a single client-argument form that only one client accepts:

| Argument form | phpredis (`\Redis`) | predis (`\Predis\Client`) |
|---|---|---|
| string `'channel'` | ❌ `Warning: Redis::pubsub(): Invalid channels value` | ✅ ok |
| array `['channel']` | ✅ ok | ❌ `Warning: Array to string conversion` |

The command used the **string** form, so it worked on predis but broke on phpredis (which is preferred whenever the native extension is loaded — the auto-detect added in #19). No single form works for both.

Because Illuminate surfaces the phpredis failure as a **PHP warning**, it also slipped past the existing `catch (\Exception)`, so the count silently fell through to `0`.

## The fix

Branch on the underlying client — matching the existing `instanceof \Redis` / `instanceof \Predis\Client` convention in `CacheSubscribeCommand` — and pass each the form it accepts. Both return an associative `[channel => count]` map, so the downstream read is unchanged. The catch is widened to `\Throwable` so a genuine failure still degrades gracefully instead of leaking a warning.

## Tests

This adds backend test scaffolding to the extension (`flarum/testing`, phpunit integration config, setup script) — previously there were none — and a `RedisInfoCommandTest`.

The subscriber-count regression test is deliberately built to **fail on the warning**, not the count: on a fresh server there are zero subscribers, so a broken and a correct read both print `0`, and only the PHP warning distinguishes them. The test installs an error handler and fails if any client-specific `PUBSUB` warning is raised. It's been verified to fail the original (string) code on phpredis, fail an array-only "fix" on predis, and pass only the client-branched fix on both.

## CI — both clients

`backend.yml` now enables backend testing and a Valkey service, and opts into the `redis_clients` matrix (added in flarum/framework#4847) to run the whole suite against **both** `phpredis` and `predis`:

```yaml
enable_redis: true
redis_variant: valkey
redis_clients: '["phpredis", "predis"]'
```

Locally verified green on both clients (4 tests / 13 assertions each) and phpstan-clean.

Requires flarum/framework#4847 (merged) for the `redis_clients` input.