### PR TITLE
[2.x] feat: Store failed jobs in Redis and feed the core queue dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ return [
 #### Queue
 
 Make sure to start your queue workers, see 
-the [laravel documentation](https://laravel.com/docs/11.x/queues#running-the-queue-worker) for specifics. 
+the [laravel documentation](https://laravel.com/docs/13.x/queues#running-the-queue-worker) for specifics. 
 To test the worker can start use `php flarum queue:work`.
 
 ##### Queue options
@@ -256,7 +256,7 @@ return [
 ```
 
 You can read up on the meaning of `retry_after`, `block_for` and `after_commit` in the
-[Laravel Documentation](https://laravel.com/docs/12.x/queues#redis).
+[Laravel Documentation](https://laravel.com/docs/13.x/queues#redis).
 
 ##### Failed jobs
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ return [
         'queue' => [
             'retry_after' => 120, // seconds
             'block_for' => 5, // seconds
-            'after_commit' => true 
+            'after_commit' => true,
+            'failed_ttl' => 604800, // seconds; how long to keep failed jobs (default 7 days)
         ]       
     ]))
     ->useDatabaseWith('cache', 1)
@@ -254,7 +255,22 @@ return [
 ];
 ```
 
-You can read up on the meaning of these options in the [Laravel Documentation](https://laravel.com/docs/12.x/queues#redis).
+You can read up on the meaning of `retry_after`, `block_for` and `after_commit` in the
+[Laravel Documentation](https://laravel.com/docs/12.x/queues#redis).
+
+##### Failed jobs
+
+When the queue runs on Redis, failed jobs are stored **in Redis** rather than in the database. Flarum
+core only records failed jobs in the database for the database queue driver; with this extension enabled,
+your failures stay on Redis so they don't add load or writes to your database. They remain fully visible
+and manageable from the admin queue dashboard (view, retry, and delete), and via the
+`php flarum queue:failed`, `queue:retry` and `queue:forget` commands.
+
+Failed jobs are given a time-to-live so they don't accumulate forever, controlled by `failed_ttl` (seconds)
+in the `queue` config above. It defaults to **7 days** (`604800`). Set it to `0` or `null` to keep failed
+jobs until they are retried or deleted. Because these entries carry a TTL, they are also eligible for
+eviction first under a `volatile-*` `maxmemory-policy`, so a memory-constrained Redis reclaims old failure
+records before touching live queue jobs.
 
 ### Migrating from `blomstra/flarum-redis`
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ return [
             'block_for' => 5, // seconds
             'after_commit' => true,
             'failed_ttl' => 604800, // seconds; how long to keep failed jobs (default 7 days)
+            'queues' => ['default'], // additional named queues (see below)
         ]       
     ]))
     ->useDatabaseWith('cache', 1)
@@ -257,6 +258,43 @@ return [
 
 You can read up on the meaning of `retry_after`, `block_for` and `after_commit` in the
 [Laravel Documentation](https://laravel.com/docs/13.x/queues#redis).
+
+##### Named queues
+
+Like Laravel Horizon, the Redis queue supports **multiple named queues**, which let you separate and
+prioritise work — for example a fast `notifications` queue that should never be held up behind slow
+`exports`.
+
+Jobs are routed to a queue by name. A job can set its own target with the core
+`AbstractJob::$onQueue` property (or Laravel's `onQueue()` method):
+
+```php
+class SendExportJob extends \Flarum\Queue\AbstractJob
+{
+    public static ?string $onQueue = 'exports';
+}
+```
+
+You then run a worker across the queues you care about, in **priority order** — the worker fully drains
+each queue before moving to the next:
+
+```sh
+php flarum queue:work --queue=notifications,default,exports
+```
+
+Because Redis has no efficient way to list every queue that exists, Flarum keeps a registry of the queue
+names admin tooling should know about (the queue dashboard and per-queue pause read it). Declare the extra
+queues your site uses in the `queues` config key so they are covered:
+
+```php
+'queue' => [
+    'queues' => ['notifications', 'exports'],
+],
+```
+
+`default` is always included automatically, so you only need to list the additional names. Queues you
+don't declare still work — jobs pushed to them are processed normally — but they won't appear in the
+dashboard or be individually pausable.
 
 ##### Failed jobs
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "flarum/core": "^2.0.0",
+        "flarum/core": "2.x-dev",
         "illuminate/redis": "^13.0",
         "predis/predis": "^v2.3.0"
     },
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "flarum/phpstan": "2.x-dev",
-        "flarum/testing": "^2.0.0"
+        "flarum/testing": "2.x-dev"
     },
     "scripts": {
         "test": [

--- a/src/Provides/Queue.php
+++ b/src/Provides/Queue.php
@@ -13,9 +13,12 @@
 
 namespace FoF\Redis\Provides;
 
+use Flarum\Queue\QueueStatsProvider;
 use FoF\Redis\Configuration;
 use FoF\Redis\Overrides\RedisManager;
 use FoF\Redis\Overrides\RedisQueue;
+use FoF\Redis\Queue\RedisFailedJobProvider;
+use FoF\Redis\Queue\RedisQueueStatsProvider;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Redis\Factory;
 use Illuminate\Support\Arr;
@@ -49,5 +52,38 @@ class Queue extends Provider
 
             return $queue;
         });
+
+        // Store failed jobs in Redis rather than losing them.
+        //
+        // Core only wires a real failer for the database queue; every other
+        // driver gets a NullFailedJobProvider that discards failures. An admin
+        // on fof/redis has deliberately moved load off the database, so their
+        // failures belong in Redis too — not back in the DB. Overriding the
+        // `queue.failer` binding here keeps them in Redis and makes core's
+        // failed-job management UI (view/retry/delete) work under Redis.
+        $container->singleton('queue.failer', function ($container) use ($configuration) {
+            $config = Arr::get($configuration->toArray(), 'queue', []);
+
+            return new RedisFailedJobProvider(
+                $container->make(Factory::class),
+                $this->connection,
+                // Default: keep a week of failure history, then let it expire.
+                // Set queue.failed_ttl to 0/null to keep failures indefinitely.
+                Arr::get($config, 'failed_ttl', 604800)
+            );
+        });
+
+        // Feed core's queue dashboard from Redis instead of the (now empty)
+        // queue_jobs table. Only meaningful on core builds that ship the
+        // QueueStatsProvider contract; guarded so older cores are unaffected.
+        if (interface_exists(QueueStatsProvider::class)) {
+            $container->singleton(QueueStatsProvider::class, function ($container) {
+                return new RedisQueueStatsProvider(
+                    $container->make('flarum.queue.connection'),
+                    $container->make('queue.failer'),
+                    $container->make('flarum.queue.queues')
+                );
+            });
+        }
     }
 }

--- a/src/Provides/Queue.php
+++ b/src/Provides/Queue.php
@@ -59,6 +59,27 @@ class Queue extends Provider
             return $queue;
         });
 
+        // Register any additional named queues the site runs.
+        //
+        // Redis (like Horizon) supports multiple named queues — a worker is
+        // started with `queue:work --queue=high,default,low` and jobs are
+        // routed to a queue via `AbstractJob::$onQueue`. There is no cheap way
+        // to enumerate queues in Redis (KEYS is O(n) and blocks the server), so
+        // core keeps a registry of known queue names (`flarum.queue.queues`,
+        // default `['default']`) that admin tooling — the queue dashboard and
+        // per-queue pause — reads. A site declares its queue names in the
+        // `queue.queues` config; we append them here so those tools cover them.
+        $container->extend('flarum.queue.queues', function ($queues) use ($configuration) {
+            $config = Arr::get($configuration->toArray(), 'queue', []);
+            $configured = Arr::get($config, 'queues', []);
+
+            return array_values(array_unique(array_merge(
+                is_array($queues) ? $queues : ['default'],
+                ['default'],
+                (array) $configured
+            )));
+        });
+
         // Store failed jobs in Redis rather than losing them.
         //
         // Core only wires a real failer for the database queue; every other

--- a/src/Provides/Queue.php
+++ b/src/Provides/Queue.php
@@ -34,7 +34,13 @@ class Queue extends Provider
             $manager->addConnection($this->connection, $configuration->toArray());
         });
 
-        $container->bind('flarum.queue.connection', function ($container) use ($configuration) {
+        // Bind as a singleton, matching core's own `flarum.queue.connection`
+        // binding. A transient binding would open a fresh Redis connection on
+        // every resolution — wasteful, and it means a component that resolves
+        // the queue separately (e.g. the stats provider) reads through a
+        // brand-new connection that may not yet observe a write made on another
+        // connection microseconds earlier. One shared connection avoids both.
+        $container->singleton('flarum.queue.connection', function ($container) use ($configuration) {
             $config = Arr::get($configuration->toArray(), 'queue', []);
 
             /** @var RedisManager $manager */

--- a/src/Queue/RedisFailedJobProvider.php
+++ b/src/Queue/RedisFailedJobProvider.php
@@ -14,10 +14,10 @@
 namespace FoF\Redis\Queue;
 
 use Illuminate\Contracts\Redis\Factory;
-use Illuminate\Redis\Connections\Connection;
 use Illuminate\Queue\Failed\CountableFailedJobProvider;
 use Illuminate\Queue\Failed\FailedJobProviderInterface;
 use Illuminate\Queue\Failed\PrunableFailedJobProvider;
+use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Carbon;
 
 /**
@@ -43,16 +43,16 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
     protected string $jobKeyPrefix;
 
     /**
-     * @param  Factory  $redis        the Redis connection factory
-     * @param  string   $connectionName  the queue's Redis connection name
-     * @param  int|null $ttl          seconds to keep a failed job before it
-     *                                expires; null/0 keeps it until forgotten.
-     *                                A TTL also makes the entry eligible for
-     *                                eviction under a `volatile-*` maxmemory
-     *                                policy, so failures can be reclaimed under
-     *                                memory pressure while untagged keys (live
-     *                                queue jobs, cache) are protected.
-     * @param  string   $prefix       key prefix for the index/hashes
+     * @param Factory  $redis          the Redis connection factory
+     * @param string   $connectionName the queue's Redis connection name
+     * @param int|null $ttl            seconds to keep a failed job before it
+     *                                 expires; null/0 keeps it until forgotten.
+     *                                 A TTL also makes the entry eligible for
+     *                                 eviction under a `volatile-*` maxmemory
+     *                                 policy, so failures can be reclaimed under
+     *                                 memory pressure while untagged keys (live
+     *                                 queue jobs, cache) are protected.
+     * @param string   $prefix         key prefix for the index/hashes
      */
     public function __construct(
         protected Factory $redis,
@@ -67,10 +67,11 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
     /**
      * Log a failed job into Redis.
      *
-     * @param  string  $connection
-     * @param  string  $queue
-     * @param  string  $payload
-     * @param  \Throwable  $exception
+     * @param string     $connection
+     * @param string     $queue
+     * @param string     $payload
+     * @param \Throwable $exception
+     *
      * @return string|int|null
      */
     public function log($connection, $queue, $payload, $exception)
@@ -110,7 +111,8 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
      * Get the IDs of all of the failed jobs (optionally for one queue),
      * newest first.
      *
-     * @param  string|null  $queue
+     * @param string|null $queue
+     *
      * @return array
      */
     public function ids($queue = null)
@@ -167,7 +169,8 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
     /**
      * Get a single failed job as an object matching the DB failer's shape.
      *
-     * @param  mixed  $id
+     * @param mixed $id
+     *
      * @return object|null
      */
     public function find($id)
@@ -184,7 +187,8 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
     /**
      * Delete a single failed job from storage.
      *
-     * @param  mixed  $id
+     * @param mixed $id
+     *
      * @return bool
      */
     public function forget($id)
@@ -200,7 +204,8 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
     /**
      * Flush all (or old) failed jobs from storage.
      *
-     * @param  int|null  $hours
+     * @param int|null $hours
+     *
      * @return void
      */
     public function flush($hours = null)
@@ -237,7 +242,7 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
             $connection->del($this->jobKeyPrefix.$id);
         }
 
-        if (! empty($ids)) {
+        if (!empty($ids)) {
             $connection->zremrangebyscore($this->indexKey, '-inf', $cutoff);
         }
 
@@ -247,8 +252,9 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
     /**
      * Count the failed jobs (optionally for one connection/queue).
      *
-     * @param  string|null  $connection
-     * @param  string|null  $queue
+     * @param string|null $connection
+     * @param string|null $queue
+     *
      * @return int
      */
     public function count($connection = null, $queue = null)

--- a/src/Queue/RedisFailedJobProvider.php
+++ b/src/Queue/RedisFailedJobProvider.php
@@ -1,0 +1,270 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Queue;
+
+use Illuminate\Contracts\Redis\Factory;
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Queue\Failed\CountableFailedJobProvider;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use Illuminate\Queue\Failed\PrunableFailedJobProvider;
+use Illuminate\Support\Carbon;
+
+/**
+ * Stores failed jobs in Redis instead of the database.
+ *
+ * Core only wires a real failer ({@see \Flarum\Queue\DatabaseUuidFailedJobProvider})
+ * for the database queue; every other driver gets a NullFailedJobProvider that
+ * silently discards failures. An admin running fof/redis has deliberately moved
+ * cache, sessions and the queue off the database to reduce its load — so their
+ * failed jobs belong in Redis too, not back in the DB. This provider keeps them
+ * there while remaining a drop-in for core's failed-job management UI (the
+ * FailedJobs service calls all()/find()/forget()/ids()).
+ *
+ * Storage layout (in the queue's Redis connection/database):
+ *   - hash `{prefix}:failed:{uuid}` — one field per column (connection, queue,
+ *     payload, exception, failed_at).
+ *   - sorted set `{prefix}:failed` — member = uuid, score = failed_at unix ts;
+ *     gives ordering (newest first), count, id listing and prune-by-age.
+ */
+class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
+{
+    protected string $indexKey;
+    protected string $jobKeyPrefix;
+
+    /**
+     * @param  Factory  $redis        the Redis connection factory
+     * @param  string   $connectionName  the queue's Redis connection name
+     * @param  int|null $ttl          seconds to keep a failed job before it
+     *                                expires; null/0 keeps it until forgotten.
+     *                                A TTL also makes the entry eligible for
+     *                                eviction under a `volatile-*` maxmemory
+     *                                policy, so failures can be reclaimed under
+     *                                memory pressure while untagged keys (live
+     *                                queue jobs, cache) are protected.
+     * @param  string   $prefix       key prefix for the index/hashes
+     */
+    public function __construct(
+        protected Factory $redis,
+        protected string $connectionName,
+        protected ?int $ttl = null,
+        string $prefix = 'queues:failed'
+    ) {
+        $this->indexKey = $prefix;
+        $this->jobKeyPrefix = $prefix.':';
+    }
+
+    /**
+     * Log a failed job into Redis.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $payload
+     * @param  \Throwable  $exception
+     * @return string|int|null
+     */
+    public function log($connection, $queue, $payload, $exception)
+    {
+        // Reuse the job's own uuid when present (Flarum/Laravel stamp one on
+        // dispatch) so retries and tracing line up; fall back to a fresh one.
+        $uuid = json_decode($payload, true)['uuid'] ?? (string) \Illuminate\Support\Str::uuid();
+
+        $failedAt = Carbon::now();
+        $jobKey = $this->jobKeyPrefix.$uuid;
+
+        $redis = $this->connection();
+
+        $redis->hmset($jobKey, [
+            'id'         => $uuid,
+            'connection' => $connection ?? '',
+            'queue'      => $queue,
+            'payload'    => $payload,
+            'exception'  => (string) mb_convert_encoding((string) $exception, 'UTF-8'),
+            'failed_at'  => $failedAt->getTimestamp(),
+        ]);
+
+        // A TTL bounds memory growth and, under a volatile-* eviction policy,
+        // lets Redis reclaim old failures under memory pressure. The index
+        // entry outlives the hash if the hash expires first; reads tolerate
+        // that and clean the dangling id.
+        if ($this->ttl !== null && $this->ttl > 0) {
+            $redis->expire($jobKey, $this->ttl);
+        }
+
+        $redis->zadd($this->indexKey, $failedAt->getTimestamp(), $uuid);
+
+        return $uuid;
+    }
+
+    /**
+     * Get the IDs of all of the failed jobs (optionally for one queue),
+     * newest first.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function ids($queue = null)
+    {
+        $redis = $this->connection();
+        $ids = [];
+
+        foreach ($redis->zrevrange($this->indexKey, 0, -1) as $id) {
+            $recordQueue = $redis->hget($this->jobKeyPrefix.$id, 'queue');
+
+            // Hash expired (TTL) but index entry lingered — drop the dangling
+            // id. A missing field is `null` on predis and `false` on phpredis,
+            // so test for either rather than an exact type.
+            if ($recordQueue === null || $recordQueue === false) {
+                $redis->zrem($this->indexKey, $id);
+
+                continue;
+            }
+
+            if ($queue === null || $recordQueue === $queue) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * Get a list of all of the failed jobs, newest first.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        $redis = $this->connection();
+        $jobs = [];
+
+        foreach ($redis->zrevrange($this->indexKey, 0, -1) as $id) {
+            $job = $this->find($id);
+
+            // Hash expired (TTL) but index entry lingered — drop the dangling id.
+            if ($job === null) {
+                $redis->zrem($this->indexKey, $id);
+
+                continue;
+            }
+
+            $jobs[] = $job;
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Get a single failed job as an object matching the DB failer's shape.
+     *
+     * @param  mixed  $id
+     * @return object|null
+     */
+    public function find($id)
+    {
+        $record = $this->connection()->hgetall($this->jobKeyPrefix.$id);
+
+        if (empty($record)) {
+            return null;
+        }
+
+        return (object) $record;
+    }
+
+    /**
+     * Delete a single failed job from storage.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function forget($id)
+    {
+        $connection = $this->connection();
+
+        $removed = (int) $connection->zrem($this->indexKey, $id);
+        $connection->del($this->jobKeyPrefix.$id);
+
+        return $removed > 0;
+    }
+
+    /**
+     * Flush all (or old) failed jobs from storage.
+     *
+     * @param  int|null  $hours
+     * @return void
+     */
+    public function flush($hours = null)
+    {
+        if ($hours === null) {
+            foreach ($this->connection()->zrange($this->indexKey, 0, -1) as $id) {
+                $this->connection()->del($this->jobKeyPrefix.$id);
+            }
+
+            $this->connection()->del($this->indexKey);
+
+            return;
+        }
+
+        $this->prune(Carbon::now()->subHours($hours));
+    }
+
+    /**
+     * Prune failed jobs older than the given date.
+     *
+     * @return int
+     */
+    public function prune(\DateTimeInterface $before)
+    {
+        $connection = $this->connection();
+
+        // Redis score-range bounds are strings ('-inf', '(5', a numeric
+        // literal, …), so pass the cutoff timestamp as a string.
+        $cutoff = (string) $before->getTimestamp();
+
+        $ids = $connection->zrangebyscore($this->indexKey, '-inf', $cutoff);
+
+        foreach ($ids as $id) {
+            $connection->del($this->jobKeyPrefix.$id);
+        }
+
+        if (! empty($ids)) {
+            $connection->zremrangebyscore($this->indexKey, '-inf', $cutoff);
+        }
+
+        return count($ids);
+    }
+
+    /**
+     * Count the failed jobs (optionally for one connection/queue).
+     *
+     * @param  string|null  $connection
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function count($connection = null, $queue = null)
+    {
+        if ($connection === null && $queue === null) {
+            return (int) $this->connection()->zcard($this->indexKey);
+        }
+
+        return count(array_filter($this->all(), function ($job) use ($connection, $queue) {
+            return ($connection === null || $job->connection === $connection)
+                && ($queue === null || $job->queue === $queue);
+        }));
+    }
+
+    protected function connection(): Connection
+    {
+        return $this->redis->connection($this->connectionName);
+    }
+}

--- a/src/Queue/RedisQueueStatsProvider.php
+++ b/src/Queue/RedisQueueStatsProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Queue;
+
+use Flarum\Queue\QueueStatsProvider;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use Illuminate\Queue\RedisQueue;
+
+/**
+ * Feeds core's queue dashboard when the queue runs on Redis.
+ *
+ * Core's default {@see \Flarum\Queue\DatabaseQueueStatsProvider} reads the
+ * `queue_jobs` table, which is empty when fof/redis has taken over the queue
+ * connection — so without this the dashboard would report an idle queue. We
+ * re-bind `QueueStatsProvider` to this class from the Redis queue provider.
+ *
+ * Counts come from the Redis queue's own public size methods (which speak to
+ * Redis via the configured client, so they work under both phpredis and
+ * predis). Failed jobs are read through the bound failer, exactly as core does
+ * — fof/redis does not register its own failer, so failures still live in the
+ * `queue_failed_jobs` table.
+ */
+class RedisQueueStatsProvider implements QueueStatsProvider
+{
+    public function __construct(
+        protected Queue $queue,
+        protected FailedJobProviderInterface $failer,
+        /** @var list<string> */
+        protected array $queues
+    ) {
+    }
+
+    public function totals(): array
+    {
+        $pending = 0;
+        $reserved = 0;
+
+        foreach ($this->queues as $queue) {
+            $pending += $this->pendingSize($queue);
+            $reserved += $this->reservedSize($queue);
+        }
+
+        return [
+            'pending'  => $pending,
+            'reserved' => $reserved,
+            'failed'   => count($this->failer->ids()),
+        ];
+    }
+
+    public function queues(): array
+    {
+        $queues = [];
+
+        foreach ($this->queues as $queue) {
+            $queues[$queue] = [
+                'pending'  => $this->pendingSize($queue),
+                'reserved' => $this->reservedSize($queue),
+            ];
+        }
+
+        return $queues;
+    }
+
+    /**
+     * Jobs waiting to be picked up (the queue list).
+     */
+    protected function pendingSize(string $queue): int
+    {
+        return $this->queue instanceof RedisQueue
+            ? (int) $this->queue->pendingSize($queue)
+            : 0;
+    }
+
+    /**
+     * Jobs a worker has reserved but not yet finished (the reserved zset).
+     */
+    protected function reservedSize(string $queue): int
+    {
+        return $this->queue instanceof RedisQueue
+            ? (int) $this->queue->reservedSize($queue)
+            : 0;
+    }
+}

--- a/tests/integration/RedisFailedJobProviderTest.php
+++ b/tests/integration/RedisFailedJobProviderTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Extend\Redis;
+use FoF\Redis\Queue\RedisFailedJobProvider;
+use Illuminate\Contracts\Redis\Factory;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use PHPUnit\Framework\Attributes\Test;
+
+class RedisFailedJobProviderTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected int $ttl = 604800;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extend(
+            (new Redis($this->redisConfig()))
+                ->useDatabaseWith('cache', 1)
+                ->useDatabaseWith('queue', 2)
+                ->useDatabaseWith('session', 3)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        // Wipe the queue DB so failed-job state never leaks between tests.
+        try {
+            $this->app()->getContainer()->make(Factory::class)->connection('default')->flushdb();
+        } catch (\Throwable $e) {
+            // Redis not reachable — the test that needs it will fail loudly.
+        }
+
+        parent::tearDown();
+    }
+
+    protected function failer(): RedisFailedJobProvider
+    {
+        return $this->app()->getContainer()->make('queue.failer');
+    }
+
+    private function payload(string $uuid, string $display = 'FoF\\Redis\\Tests\\FakeJob'): string
+    {
+        return json_encode(['uuid' => $uuid, 'displayName' => $display, 'job' => $display]);
+    }
+
+    #[Test]
+    public function it_overrides_the_null_failer_with_a_redis_one()
+    {
+        $failer = $this->failer();
+
+        $this->assertInstanceOf(RedisFailedJobProvider::class, $failer);
+        $this->assertInstanceOf(FailedJobProviderInterface::class, $failer);
+    }
+
+    #[Test]
+    public function it_logs_and_finds_a_failed_job_with_the_expected_shape()
+    {
+        $failer = $this->failer();
+
+        $id = $failer->log('redis', 'default', $this->payload('uuid-1'), new \RuntimeException('boom'));
+
+        $this->assertSame('uuid-1', $id);
+
+        $job = $failer->find($id);
+        $this->assertNotNull($job);
+        // The management UI (Flarum\Queue\FailedJobs::all) reads exactly these.
+        $this->assertSame('uuid-1', $job->id);
+        $this->assertSame('redis', $job->connection);
+        $this->assertSame('default', $job->queue);
+        $this->assertSame($this->payload('uuid-1'), $job->payload);
+        $this->assertStringContainsString('boom', $job->exception);
+        $this->assertNotEmpty($job->failed_at);
+    }
+
+    #[Test]
+    public function find_returns_null_for_an_unknown_id()
+    {
+        $this->assertNull($this->failer()->find('does-not-exist'));
+    }
+
+    #[Test]
+    public function it_counts_and_lists_failed_jobs()
+    {
+        $failer = $this->failer();
+
+        $this->assertSame(0, $failer->count());
+        $this->assertSame([], $failer->all());
+        $this->assertSame([], $failer->ids());
+
+        $failer->log('redis', 'default', $this->payload('a'), new \RuntimeException('a'));
+        $failer->log('redis', 'emails', $this->payload('b'), new \RuntimeException('b'));
+
+        $this->assertSame(2, $failer->count());
+        $this->assertCount(2, $failer->all());
+        $this->assertEqualsCanonicalizing(['a', 'b'], $failer->ids());
+    }
+
+    #[Test]
+    public function ids_and_count_can_filter_by_queue()
+    {
+        $failer = $this->failer();
+
+        $failer->log('redis', 'default', $this->payload('a'), new \RuntimeException('a'));
+        $failer->log('redis', 'emails', $this->payload('b'), new \RuntimeException('b'));
+        $failer->log('redis', 'emails', $this->payload('c'), new \RuntimeException('c'));
+
+        $this->assertEqualsCanonicalizing(['b', 'c'], $failer->ids('emails'));
+        $this->assertSame(2, $failer->count(null, 'emails'));
+        $this->assertSame(1, $failer->count(null, 'default'));
+    }
+
+    #[Test]
+    public function all_returns_newest_first()
+    {
+        $failer = $this->failer();
+
+        // Force distinct, ascending timestamps.
+        \Illuminate\Support\Carbon::setTestNow(\Illuminate\Support\Carbon::now());
+        $failer->log('redis', 'default', $this->payload('older'), new \RuntimeException('1'));
+        \Illuminate\Support\Carbon::setTestNow(\Illuminate\Support\Carbon::now()->addSeconds(10));
+        $failer->log('redis', 'default', $this->payload('newer'), new \RuntimeException('2'));
+        \Illuminate\Support\Carbon::setTestNow();
+
+        $ids = array_map(fn ($j) => $j->id, $failer->all());
+        $this->assertSame(['newer', 'older'], $ids);
+    }
+
+    #[Test]
+    public function forget_removes_a_single_job()
+    {
+        $failer = $this->failer();
+
+        $failer->log('redis', 'default', $this->payload('keep'), new \RuntimeException('k'));
+        $failer->log('redis', 'default', $this->payload('drop'), new \RuntimeException('d'));
+
+        $this->assertTrue($failer->forget('drop'));
+        $this->assertFalse($failer->forget('drop'), 'forgetting a gone id returns false');
+
+        $this->assertSame(1, $failer->count());
+        $this->assertNull($failer->find('drop'));
+        $this->assertNotNull($failer->find('keep'));
+    }
+
+    #[Test]
+    public function flush_without_argument_clears_everything()
+    {
+        $failer = $this->failer();
+
+        $failer->log('redis', 'default', $this->payload('a'), new \RuntimeException('a'));
+        $failer->log('redis', 'default', $this->payload('b'), new \RuntimeException('b'));
+
+        $failer->flush();
+
+        $this->assertSame(0, $failer->count());
+        $this->assertSame([], $failer->all());
+    }
+
+    #[Test]
+    public function flush_with_hours_only_prunes_old_jobs()
+    {
+        $failer = $this->failer();
+
+        // Old job: failed 48h ago.
+        \Illuminate\Support\Carbon::setTestNow(\Illuminate\Support\Carbon::now()->subHours(48));
+        $failer->log('redis', 'default', $this->payload('old'), new \RuntimeException('old'));
+        \Illuminate\Support\Carbon::setTestNow();
+        // Recent job: just now.
+        $failer->log('redis', 'default', $this->payload('recent'), new \RuntimeException('recent'));
+
+        // Flush anything older than 24h.
+        $failer->flush(24);
+
+        $this->assertNull($failer->find('old'));
+        $this->assertNotNull($failer->find('recent'));
+        $this->assertSame(1, $failer->count());
+    }
+
+    #[Test]
+    public function prune_removes_jobs_before_a_date_and_returns_the_count()
+    {
+        $failer = $this->failer();
+
+        \Illuminate\Support\Carbon::setTestNow(\Illuminate\Support\Carbon::now()->subDays(10));
+        $failer->log('redis', 'default', $this->payload('x'), new \RuntimeException('x'));
+        $failer->log('redis', 'default', $this->payload('y'), new \RuntimeException('y'));
+        \Illuminate\Support\Carbon::setTestNow();
+        $failer->log('redis', 'default', $this->payload('z'), new \RuntimeException('z'));
+
+        $pruned = $failer->prune(\Illuminate\Support\Carbon::now()->subDays(1));
+
+        $this->assertSame(2, $pruned);
+        $this->assertSame(1, $failer->count());
+        $this->assertNotNull($failer->find('z'));
+    }
+
+    #[Test]
+    public function it_applies_the_configured_ttl_to_stored_jobs()
+    {
+        $failer = $this->failer();
+        $id = $failer->log('redis', 'default', $this->payload('ttl'), new \RuntimeException('t'));
+
+        $conn = $this->app()->getContainer()->make(Factory::class)->connection('default');
+        $ttl = (int) $conn->ttl('queues:failed:'.$id);
+
+        // Should carry a positive TTL close to the configured 7 days (allow slack).
+        $this->assertGreaterThan(0, $ttl);
+        $this->assertLessThanOrEqual($this->ttl, $ttl);
+        $this->assertGreaterThan($this->ttl - 60, $ttl);
+    }
+
+    #[Test]
+    public function reads_tolerate_a_hash_that_expired_out_from_under_the_index()
+    {
+        $failer = $this->failer();
+        $conn = $this->app()->getContainer()->make(Factory::class)->connection('default');
+
+        $failer->log('redis', 'default', $this->payload('live'), new \RuntimeException('l'));
+        $failer->log('redis', 'default', $this->payload('ghost'), new \RuntimeException('g'));
+
+        // Simulate the ghost's hash being evicted/expired while its index entry lingers.
+        $conn->del('queues:failed:ghost');
+
+        // all()/ids()/count-via-all must skip the dangling id and self-heal the index.
+        $this->assertSame(['live'], $failer->ids());
+        $this->assertCount(1, $failer->all());
+        // The stale index member is cleaned up by the read (zscore of a gone
+        // member is null on predis / false on phpredis — never a real score).
+        $this->assertEmpty($conn->zscore('queues:failed', 'ghost'));
+    }
+}

--- a/tests/integration/RedisFailedJobProviderTest.php
+++ b/tests/integration/RedisFailedJobProviderTest.php
@@ -30,24 +30,38 @@ class RedisFailedJobProviderTest extends TestCase
     {
         parent::setUp();
 
+        // Use high, dedicated Redis databases for tests. A local dev stack may
+        // have a real `queue:work` worker draining the usual queue database
+        // (1-3) on the same Redis server, which would consume the jobs these
+        // tests push and make assertions flaky. Databases 13-15 are reserved
+        // for the test suite and touched by nothing else. (CI runs a dedicated
+        // Redis with no worker, so this is belt-and-suspenders there.)
         $this->extend(
             (new Redis($this->redisConfig()))
-                ->useDatabaseWith('cache', 1)
-                ->useDatabaseWith('queue', 2)
-                ->useDatabaseWith('session', 3)
+                ->useDatabaseWith('cache', 13)
+                ->useDatabaseWith('queue', 14)
+                ->useDatabaseWith('session', 15)
         );
+
+        // Start from a clean queue database. Tests share one Redis instance, so
+        // residue from a previous test would otherwise skew the counts here.
+        $this->flushQueueDatabase();
     }
 
     protected function tearDown(): void
     {
-        // Wipe the queue DB so failed-job state never leaks between tests.
+        $this->flushQueueDatabase();
+
+        parent::tearDown();
+    }
+
+    protected function flushQueueDatabase(): void
+    {
         try {
             $this->app()->getContainer()->make(Factory::class)->connection('default')->flushdb();
         } catch (\Throwable $e) {
             // Redis not reachable — the test that needs it will fail loudly.
         }
-
-        parent::tearDown();
     }
 
     protected function failer(): RedisFailedJobProvider

--- a/tests/integration/RedisFailedJobProviderTest.php
+++ b/tests/integration/RedisFailedJobProviderTest.php
@@ -31,16 +31,20 @@ class RedisFailedJobProviderTest extends TestCase
         parent::setUp();
 
         // Use high, dedicated Redis databases for tests. A local dev stack may
-        // have a real `queue:work` worker draining the usual queue database
-        // (1-3) on the same Redis server, which would consume the jobs these
-        // tests push and make assertions flaky. Databases 13-15 are reserved
-        // for the test suite and touched by nothing else. (CI runs a dedicated
-        // Redis with no worker, so this is belt-and-suspenders there.)
+        // run a `queue:work` worker on the usual queue database, and keeps its
+        // cache/settings on low databases, all on the same Redis server. Tests
+        // that fell back onto those would consume the dev worker's jobs or
+        // overwrite the dev forum's live cache/settings. Databases 12-15 are
+        // reserved for the suite. Every service is pinned explicitly — an
+        // unpinned service falls back to the base `database`, which must never
+        // be a live one (see RedisTestConfig). (CI uses a dedicated Redis, so
+        // this is belt-and-suspenders there.)
         $this->extend(
             (new Redis($this->redisConfig()))
                 ->useDatabaseWith('cache', 13)
                 ->useDatabaseWith('queue', 14)
                 ->useDatabaseWith('session', 15)
+                ->useDatabaseWith('settings', 12)
         );
 
         // Start from a clean queue database. Tests share one Redis instance, so
@@ -57,8 +61,23 @@ class RedisFailedJobProviderTest extends TestCase
 
     protected function flushQueueDatabase(): void
     {
+        // Flush directly via a raw client rather than through the container, so
+        // this does not boot the app before the test has finished registering.
         try {
-            $this->app()->getContainer()->make(Factory::class)->connection('default')->flushdb();
+            $config = $this->redisConfig();
+            $host = $config['host'];
+            $port = (int) $config['port'];
+
+            if (extension_loaded('redis')) {
+                $client = new \Redis();
+                $client->connect($host, $port);
+                $client->select(14); // the dedicated test queue database
+                $client->flushdb();
+                $client->close();
+            } else {
+                $client = new \Predis\Client(['scheme' => 'tcp', 'host' => $host, 'port' => $port, 'database' => 14]);
+                $client->flushdb();
+            }
         } catch (\Throwable $e) {
             // Redis not reachable — the test that needs it will fail loudly.
         }

--- a/tests/integration/RedisInfoCommandTest.php
+++ b/tests/integration/RedisInfoCommandTest.php
@@ -25,11 +25,18 @@ class RedisInfoCommandTest extends ConsoleTestCase
     {
         parent::setUp();
 
+        // Use high, dedicated Redis databases for tests. A local dev stack
+        // keeps its cache/queue/session on low databases (1-3) of the same
+        // Redis server; tests that used those would clear the dev forum's live
+        // cache (its settings cache included, making extensions look disabled).
+        // Databases 12-15 are reserved for the suite. (CI uses a dedicated
+        // Redis, so this is belt-and-suspenders there.)
         $this->extend(
             (new Redis($this->redisConfig()))
-                ->useDatabaseWith('cache', 1)
-                ->useDatabaseWith('queue', 2)
-                ->useDatabaseWith('session', 3)
+                ->useDatabaseWith('cache', 13)
+                ->useDatabaseWith('queue', 14)
+                ->useDatabaseWith('session', 15)
+                ->useDatabaseWith('settings', 12)
         );
     }
 

--- a/tests/integration/RedisQueueStatsProviderTest.php
+++ b/tests/integration/RedisQueueStatsProviderTest.php
@@ -28,22 +28,34 @@ class RedisQueueStatsProviderTest extends TestCase
     {
         parent::setUp();
 
-        // Use high, dedicated Redis databases for tests. A local dev stack may
-        // have a real `queue:work` worker draining the usual queue database
-        // (1-3) on the same Redis server, which would consume the jobs these
-        // tests push and make assertions flaky. Databases 13-15 are reserved
-        // for the test suite and touched by nothing else. (CI runs a dedicated
-        // Redis with no worker, so this is belt-and-suspenders there.)
-        $this->extend(
-            (new Redis($this->redisConfig()))
-                ->useDatabaseWith('cache', 13)
-                ->useDatabaseWith('queue', 14)
-                ->useDatabaseWith('session', 15)
-        );
+        $this->registerRedis();
 
         // Start from a clean queue database. Tests share one Redis instance, so
         // residue from a previous test would otherwise skew the counts here.
         $this->flushQueueDatabase();
+    }
+
+    /**
+     * Register the Redis extender. Tests share one Redis instance, so use high,
+     * dedicated databases (13-15): a local dev stack may run a `queue:work`
+     * worker on the usual queue database on the same server, which would
+     * consume the jobs these tests push and make assertions flaky. (CI uses a
+     * dedicated Redis with no worker, so this is belt-and-suspenders there.)
+     *
+     * @param array $queueConfig extra keys merged into the `queue` config block
+     */
+    protected function registerRedis(array $queueConfig = []): void
+    {
+        $config = $this->redisConfig();
+        $config['queue'] = array_merge($config['queue'] ?? [], $queueConfig);
+
+        $this->extend(
+            (new Redis($config))
+                ->useDatabaseWith('cache', 13)
+                ->useDatabaseWith('queue', 14)
+                ->useDatabaseWith('session', 15)
+                ->useDatabaseWith('settings', 12)
+        );
     }
 
     protected function tearDown(): void
@@ -55,8 +67,25 @@ class RedisQueueStatsProviderTest extends TestCase
 
     protected function flushQueueDatabase(): void
     {
+        // Flush directly via a raw client rather than through the container, so
+        // this does NOT boot the app. Booting here would lock in the extenders
+        // registered so far, preventing a test from registering extra queue
+        // config (which must happen before boot).
         try {
-            $this->app()->getContainer()->make(Factory::class)->connection('default')->flushdb();
+            $config = $this->redisConfig();
+            $host = $config['host'];
+            $port = (int) $config['port'];
+
+            if (extension_loaded('redis')) {
+                $client = new \Redis();
+                $client->connect($host, $port);
+                $client->select(14); // the dedicated test queue database
+                $client->flushdb();
+                $client->close();
+            } else {
+                $client = new \Predis\Client(['scheme' => 'tcp', 'host' => $host, 'port' => $port, 'database' => 14]);
+                $client->flushdb();
+            }
         } catch (\Throwable $e) {
             // Redis not reachable — a redis-dependent test will fail loudly.
         }
@@ -114,5 +143,43 @@ class RedisQueueStatsProviderTest extends TestCase
         $failer->log('redis', 'default', json_encode(['uuid' => 'f1', 'displayName' => 'X']), new \RuntimeException('x'));
 
         $this->assertSame(1, $this->stats()->totals()['failed']);
+    }
+
+    #[Test]
+    public function configured_named_queues_are_registered_and_reported()
+    {
+        // A site that runs `queue:work --queue=emails,default` declares those
+        // names in the fof/redis `queue.queues` config; fof/redis appends them
+        // to core's known-queues registry so admin tooling (the dashboard,
+        // per-queue pause) covers them.
+        $this->registerRedis(['queues' => ['emails', 'notifications']]);
+
+        // The core registry now includes the configured names plus 'default'.
+        $known = $this->app()->getContainer()->make('flarum.queue.queues');
+        $this->assertEqualsCanonicalizing(['default', 'emails', 'notifications'], $known);
+
+        // And the stats provider reports a bucket for each.
+        $queues = $this->stats()->queues();
+        $this->assertArrayHasKey('default', $queues);
+        $this->assertArrayHasKey('emails', $queues);
+        $this->assertArrayHasKey('notifications', $queues);
+    }
+
+    #[Test]
+    public function totals_sum_pending_across_named_queues()
+    {
+        $this->registerRedis(['queues' => ['emails']]);
+
+        $queue = $this->app()->getContainer()->make('flarum.queue.connection');
+        $queue->pushRaw(json_encode(['uuid' => 'd1', 'displayName' => 'X']), 'default');
+        $queue->pushRaw(json_encode(['uuid' => 'e1', 'displayName' => 'X']), 'emails');
+        $queue->pushRaw(json_encode(['uuid' => 'e2', 'displayName' => 'X']), 'emails');
+
+        $totals = $this->stats()->totals();
+        $this->assertSame(3, $totals['pending']);
+
+        $queues = $this->stats()->queues();
+        $this->assertSame(1, $queues['default']['pending']);
+        $this->assertSame(2, $queues['emails']['pending']);
     }
 }

--- a/tests/integration/RedisQueueStatsProviderTest.php
+++ b/tests/integration/RedisQueueStatsProviderTest.php
@@ -17,7 +17,6 @@ use Flarum\Queue\QueueStatsProvider;
 use Flarum\Testing\integration\TestCase;
 use FoF\Redis\Extend\Redis;
 use FoF\Redis\Queue\RedisQueueStatsProvider;
-use Illuminate\Contracts\Redis\Factory;
 use PHPUnit\Framework\Attributes\Test;
 
 class RedisQueueStatsProviderTest extends TestCase
@@ -40,7 +39,7 @@ class RedisQueueStatsProviderTest extends TestCase
      * dedicated databases (13-15): a local dev stack may run a `queue:work`
      * worker on the usual queue database on the same server, which would
      * consume the jobs these tests push and make assertions flaky. (CI uses a
-     * dedicated Redis with no worker, so this is belt-and-suspenders there.)
+     * dedicated Redis with no worker, so this is belt-and-suspenders there.).
      *
      * @param array $queueConfig extra keys merged into the `queue` config block
      */

--- a/tests/integration/RedisQueueStatsProviderTest.php
+++ b/tests/integration/RedisQueueStatsProviderTest.php
@@ -28,23 +28,38 @@ class RedisQueueStatsProviderTest extends TestCase
     {
         parent::setUp();
 
+        // Use high, dedicated Redis databases for tests. A local dev stack may
+        // have a real `queue:work` worker draining the usual queue database
+        // (1-3) on the same Redis server, which would consume the jobs these
+        // tests push and make assertions flaky. Databases 13-15 are reserved
+        // for the test suite and touched by nothing else. (CI runs a dedicated
+        // Redis with no worker, so this is belt-and-suspenders there.)
         $this->extend(
             (new Redis($this->redisConfig()))
-                ->useDatabaseWith('cache', 1)
-                ->useDatabaseWith('queue', 2)
-                ->useDatabaseWith('session', 3)
+                ->useDatabaseWith('cache', 13)
+                ->useDatabaseWith('queue', 14)
+                ->useDatabaseWith('session', 15)
         );
+
+        // Start from a clean queue database. Tests share one Redis instance, so
+        // residue from a previous test would otherwise skew the counts here.
+        $this->flushQueueDatabase();
     }
 
     protected function tearDown(): void
     {
+        $this->flushQueueDatabase();
+
+        parent::tearDown();
+    }
+
+    protected function flushQueueDatabase(): void
+    {
         try {
             $this->app()->getContainer()->make(Factory::class)->connection('default')->flushdb();
         } catch (\Throwable $e) {
-            // ignored — a redis-dependent test will fail loudly on its own
+            // Redis not reachable — a redis-dependent test will fail loudly.
         }
-
-        parent::tearDown();
     }
 
     protected function stats(): QueueStatsProvider

--- a/tests/integration/RedisQueueStatsProviderTest.php
+++ b/tests/integration/RedisQueueStatsProviderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Queue\QueueStatsProvider;
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Extend\Redis;
+use FoF\Redis\Queue\RedisQueueStatsProvider;
+use Illuminate\Contracts\Redis\Factory;
+use PHPUnit\Framework\Attributes\Test;
+
+class RedisQueueStatsProviderTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extend(
+            (new Redis($this->redisConfig()))
+                ->useDatabaseWith('cache', 1)
+                ->useDatabaseWith('queue', 2)
+                ->useDatabaseWith('session', 3)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            $this->app()->getContainer()->make(Factory::class)->connection('default')->flushdb();
+        } catch (\Throwable $e) {
+            // ignored — a redis-dependent test will fail loudly on its own
+        }
+
+        parent::tearDown();
+    }
+
+    protected function stats(): QueueStatsProvider
+    {
+        return $this->app()->getContainer()->make(QueueStatsProvider::class);
+    }
+
+    #[Test]
+    public function it_overrides_core_with_the_redis_stats_provider()
+    {
+        $this->assertInstanceOf(RedisQueueStatsProvider::class, $this->stats());
+    }
+
+    #[Test]
+    public function totals_has_the_expected_keys_and_starts_empty()
+    {
+        $totals = $this->stats()->totals();
+
+        $this->assertSame(['pending', 'reserved', 'failed'], array_keys($totals));
+        $this->assertSame(0, $totals['pending']);
+        $this->assertSame(0, $totals['reserved']);
+        $this->assertSame(0, $totals['failed']);
+    }
+
+    #[Test]
+    public function queues_reports_each_known_queue()
+    {
+        $queues = $this->stats()->queues();
+
+        // Core's default known-queues registry is ['default'].
+        $this->assertArrayHasKey('default', $queues);
+        $this->assertSame(['pending', 'reserved'], array_keys($queues['default']));
+    }
+
+    #[Test]
+    public function totals_pending_reflects_jobs_pushed_onto_redis()
+    {
+        $queue = $this->app()->getContainer()->make('flarum.queue.connection');
+
+        $queue->pushRaw(json_encode(['uuid' => 'p1', 'displayName' => 'X']), 'default');
+        $queue->pushRaw(json_encode(['uuid' => 'p2', 'displayName' => 'X']), 'default');
+
+        $totals = $this->stats()->totals();
+        $this->assertSame(2, $totals['pending']);
+        $this->assertSame(2, $this->stats()->queues()['default']['pending']);
+    }
+
+    #[Test]
+    public function totals_failed_reflects_the_redis_failer()
+    {
+        $failer = $this->app()->getContainer()->make('queue.failer');
+        $failer->log('redis', 'default', json_encode(['uuid' => 'f1', 'displayName' => 'X']), new \RuntimeException('x'));
+
+        $this->assertSame(1, $this->stats()->totals()['failed']);
+    }
+}

--- a/tests/integration/RedisTestConfig.php
+++ b/tests/integration/RedisTestConfig.php
@@ -28,7 +28,13 @@ trait RedisTestConfig
             'host'        => getenv('REDIS_HOST') ?: '127.0.0.1',
             'password'    => null,
             'port'        => (int) (getenv('REDIS_PORT') ?: 6379),
-            'database'    => 1,
+            // Base database for any service without an explicit useDatabaseWith
+            // override. Deliberately high: a local dev stack keeps its cache /
+            // settings on low databases (0-4) of the same Redis server, and a
+            // service that fell back to those would let tests overwrite the dev
+            // forum's live data (e.g. the settings cache). 12 is reserved for
+            // the suite, distinct from the queue/cache/session test databases.
+            'database'    => 12,
             'prefix'      => '',
             'pubsub'      => [
                 'enabled'   => true,


### PR DESCRIPTION
> **Draft for review.** Depends on a core build that ships `Flarum\Queue\QueueStatsProvider` (added after rc.5). The `flarum/core` constraint is temporarily `2.x-dev` — see *Release gating* below.

## Problem

Core only wires a real failed-job store **and** a stats provider for the **database** queue:

- `queue.failer` resolves to `NullFailedJobProvider` for any non-DB queue → **failed jobs are silently discarded** under Redis, and the failed-job management UI added in flarum/framework#4846 (view / retry / delete) has nothing to manage.
- `QueueStatsProvider` defaults to `DatabaseQueueStatsProvider`, which reads the (now empty) `queue_jobs` table → the queue dashboard reports an **idle queue** even when Redis is busy.

## What this adds

Two providers, both bound from the Redis queue provider (`src/Provides/Queue.php`):

### `RedisFailedJobProvider`
Stores failures **in Redis, not the database**. An admin running fof/redis has deliberately moved cache/sessions/queue off the DB to reduce its load — routing failures back into MySQL would defeat that. Layout:

- hash `queues:failed:{uuid}` — `id`, `connection`, `queue`, `payload`, `exception`, `failed_at`
- sorted set `queues:failed` — member = uuid, score = failed-at timestamp (ordering, count, ids, prune-by-age)

Notable behaviour:
- **Configurable TTL** via `queue.failed_ttl` (default **7 days**; `0`/`null` = keep forever). A TTL bounds memory and, under a `volatile-*` maxmemory policy, lets Redis reclaim old failures under memory pressure while untagged keys (live jobs, cache) are protected.
- Reads **tolerate a hash that expired out from under the index** (skip + self-heal the dangling id).
- Implements `FailedJobProviderInterface` + `CountableFailedJobProvider` + `PrunableFailedJobProvider`, so core's `FailedJobs` service — and therefore the dashboard's view/retry/delete — works unchanged under Redis.

### `RedisQueueStatsProvider`
Feeds core's queue dashboard from Redis: pending/reserved per known queue (via the queue's own `pendingSize()`/`reservedSize()`), failures via the bound failer. Guarded with `interface_exists()` so older cores are unaffected.

## Tests

Integration tests for both providers (`RedisFailedJobProviderTest`, `RedisQueueStatsProviderTest`), run against **both** the phpredis and predis clients via the `redis_clients` CI matrix. 21 tests / 64 assertions green on both clients locally; phpstan clean.

TDD caught a genuine cross-client bug during development: `hget` on a missing key returns `false` on phpredis but `null` on predis, so the dangling-index cleanup only worked on predis until fixed.

## Release gating

`RedisQueueStatsProvider implements Flarum\Queue\QueueStatsProvider`, which only exists in core after rc.5. The `flarum/core` requirement is set to `2.x-dev` so this resolves today; **it should be tightened to the first released core that ships the interface (rc.6) before this leaves draft.** The failer half has no such dependency (it only uses Laravel's `FailedJobProviderInterface`).