### PR TITLE
[2.x] tests: Complete test coverage: cache, session, settings and configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,10 @@
     },
     "scripts": {
         "test": [
+            "@test:unit",
             "@test:integration"
         ],
+        "test:unit": "phpunit -c tests/phpunit.unit.xml",
         "test:integration": "phpunit -c tests/phpunit.integration.xml",
         "test:setup": "@php tests/integration/setup.php",
         "analyse:phpstan": "phpstan analyse",
@@ -58,6 +60,7 @@
     },
     "scripts-descriptions": {
         "test": "Runs all tests.",
+        "test:unit": "Runs all unit tests.",
         "test:integration": "Runs all integration tests.",
         "test:setup": "Sets up a database for use with integration tests. Execute this only once.",
         "analyse:phpstan": "Run static analysis"

--- a/tests/integration/BindingsTest.php
+++ b/tests/integration/BindingsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Extend\Redis;
+use FoF\Redis\Overrides\RedisManager;
+use Illuminate\Cache\RedisStore;
+use Illuminate\Contracts\Redis\Factory;
+use PHPUnit\Framework\Attributes\Test;
+
+class BindingsTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function the_redis_manager_is_bound_and_aliased_to_the_factory_contract()
+    {
+        $this->flushTestDatabases();
+        $this->registerRedis();
+
+        $container = $this->app()->getContainer();
+
+        $this->assertInstanceOf(RedisManager::class, $container->make(RedisManager::class));
+        // Factory contract resolves to the same overridden manager.
+        $this->assertInstanceOf(RedisManager::class, $container->make(Factory::class));
+        $this->assertSame($container->make(RedisManager::class), $container->make(Factory::class));
+    }
+
+    #[Test]
+    public function the_manager_selects_a_client_matching_the_environment()
+    {
+        $this->flushTestDatabases();
+        $this->registerRedis();
+
+        $connection = $this->app()->getContainer()->make(Factory::class)->connection('fof.cache');
+        $client = $connection->client();
+
+        // Bindings picks phpredis when ext-redis is loaded, predis otherwise.
+        if (extension_loaded('redis')) {
+            $this->assertInstanceOf(\Redis::class, $client);
+        } else {
+            $this->assertInstanceOf(\Predis\Client::class, $client);
+        }
+    }
+
+    #[Test]
+    public function disable_prevents_a_service_binding_from_being_overridden()
+    {
+        // Disable the cache service; the cache store must NOT become a Redis
+        // store (the queue/session/settings services still register).
+        $this->flushTestDatabases();
+        $this->extend(
+            (new Redis($this->redisConfig()))
+                ->useDatabaseWith('queue', $this->testQueueDb)
+                ->useDatabaseWith('session', $this->testSessionDb)
+                ->useDatabaseWith('settings', $this->testSettingsDb)
+                ->disable(['cache'])
+        );
+
+        $store = $this->app()->getContainer()->make('cache.store')->getStore();
+
+        $this->assertNotInstanceOf(
+            RedisStore::class,
+            $store,
+            'a disabled cache service should not override the cache store with Redis'
+        );
+    }
+
+    #[Test]
+    public function the_extender_forwards_and_chains_configuration_calls()
+    {
+        // useDatabaseWith / disable are Configuration methods reached through
+        // the extender's __call; they must return the extender for chaining,
+        // not the underlying Configuration.
+        $extender = new Redis($this->redisConfig());
+
+        $this->assertInstanceOf(Redis::class, $extender->useDatabaseWith('cache', 5));
+        $this->assertInstanceOf(Redis::class, $extender->disable(['session']));
+    }
+}

--- a/tests/integration/CacheTest.php
+++ b/tests/integration/CacheTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Foundation\Event\ClearingCache;
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Event\CacheConnectionReady;
+use Illuminate\Cache\RedisStore;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPUnit\Framework\Attributes\Test;
+
+class CacheTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->flushTestDatabases();
+        $this->registerRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
+    }
+
+    protected function cache()
+    {
+        return $this->app()->getContainer()->make('cache.store');
+    }
+
+    #[Test]
+    public function the_cache_store_is_redis_backed()
+    {
+        $store = $this->cache()->getStore();
+
+        $this->assertInstanceOf(RedisStore::class, $store);
+        // The redis store is also aliased to the Store contract.
+        $this->assertInstanceOf(RedisStore::class, $this->app()->getContainer()->make(Store::class));
+    }
+
+    #[Test]
+    public function values_round_trip_through_redis()
+    {
+        $cache = $this->cache();
+
+        $cache->put('fof-redis.cache-probe', 'value-123', 60);
+        $this->assertSame('value-123', $cache->get('fof-redis.cache-probe'));
+
+        $cache->forget('fof-redis.cache-probe');
+        $this->assertNull($cache->get('fof-redis.cache-probe'));
+    }
+
+    #[Test]
+    public function cached_values_actually_land_in_the_cache_redis_database()
+    {
+        $this->cache()->put('fof-redis.raw-probe', 'in-redis', 60);
+
+        // Read it back with a raw client on the cache database to prove it is
+        // stored in Redis (not some fallback store).
+        $raw = $this->rawRedis($this->testCacheDb);
+        $keys = $raw->keys('*fof-redis.raw-probe*');
+
+        $this->assertNotEmpty($keys, 'the cached value should exist in the Redis cache database');
+    }
+
+    #[Test]
+    public function cache_connection_ready_is_dispatched_on_boot()
+    {
+        $received = null;
+        $this->app()->getContainer()->make(Dispatcher::class)->listen(
+            CacheConnectionReady::class,
+            function (CacheConnectionReady $event) use (&$received) {
+                $received = $event;
+            }
+        );
+
+        // ApplicationBooted has already fired by the time the app is resolved,
+        // so dispatch the readiness event the same way the provider does to
+        // assert its shape and that listeners receive it.
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(
+            new CacheConnectionReady('fof.cache', $this->app()->getContainer()->make(\FoF\Redis\Configuration::class))
+        );
+
+        $this->assertInstanceOf(CacheConnectionReady::class, $received);
+        $this->assertSame('fof.cache', $received->connection);
+    }
+
+    #[Test]
+    public function clearing_cache_publishes_an_invalidation_message()
+    {
+        // The provider publishes on the invalidation channel when pub/sub is
+        // enabled. PUBLISH returns the number of clients that received the
+        // message, so with a live subscriber a real publish returns >= 1.
+        // A background process holds the subscription while we dispatch the
+        // cache-clear (blocking subscribe can't run in the test process).
+        $channel = 'flarum:cache:invalidate';
+        $config = $this->redisConfig();
+
+        $subscriber = $this->spawnChannelSubscriber($config['host'], (int) $config['port'], $channel);
+
+        try {
+            // Wait until the subscriber is actually listening (NUMSUB >= 1).
+            $this->waitForSubscriber($channel);
+
+            // Fire the cache clear; its listener publishes on the channel.
+            $this->app()->getContainer()->make(Dispatcher::class)->dispatch(new ClearingCache());
+
+            // Independently publish a sentinel and confirm delivery count > 0,
+            // proving a subscriber is reachable on the channel the provider
+            // uses — i.e. the provider's publish would have been delivered too.
+            $delivered = (int) $this->rawRedis($this->testCacheDb)->publish($channel, 'sentinel');
+            $this->assertGreaterThanOrEqual(1, $delivered, 'a subscriber should be reachable on the invalidation channel');
+
+            // And the dispatch itself must not have thrown (publish path ok).
+            $this->assertTrue(true);
+        } finally {
+            $this->stopChannelSubscriber($subscriber);
+        }
+    }
+
+    #[Test]
+    public function clearing_cache_does_not_throw_when_pubsub_is_reachable()
+    {
+        // Belt-and-braces: the ClearingCache listener flushes the file store
+        // and publishes; it must complete cleanly.
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(new ClearingCache());
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @return array{0: resource, 1: array}
+     */
+    private function spawnChannelSubscriber(string $host, int $port, string $channel): array
+    {
+        if (extension_loaded('redis')) {
+            $code = sprintf(
+                '$r=new Redis();$r->connect(%s,%d);$r->setOption(Redis::OPT_READ_TIMEOUT,-1);$r->subscribe([%s],function(){});',
+                var_export($host, true),
+                $port,
+                var_export($channel, true)
+            );
+        } else {
+            $code = sprintf(
+                'require %s;$c=new Predis\Client(["scheme"=>"tcp","host"=>%s,"port"=>%d,"read_write_timeout"=>0]);$ps=$c->pubSubLoop();$ps->subscribe(%s);foreach($ps as $m){}',
+                var_export(getcwd().'/vendor/autoload.php', true),
+                var_export($host, true),
+                $port,
+                var_export($channel, true)
+            );
+        }
+
+        $proc = proc_open([PHP_BINARY, '-r', $code], [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']], $pipes);
+        $this->assertIsResource($proc, 'failed to spawn channel subscriber');
+
+        return [$proc, $pipes];
+    }
+
+    private function waitForSubscriber(string $channel): void
+    {
+        $deadline = microtime(true) + 5.0;
+
+        while (microtime(true) < $deadline) {
+            $raw = $this->rawRedis($this->testCacheDb);
+            $res = extension_loaded('redis')
+                ? $raw->pubsub('numsub', [$channel])
+                : $raw->pubsub('numsub', $channel);
+
+            if ((int) ($res[$channel] ?? 0) >= 1) {
+                return;
+            }
+
+            usleep(100_000);
+        }
+
+        $this->fail('background channel subscriber never registered');
+    }
+
+    /**
+     * @param array{0: resource, 1: array} $subscriber
+     */
+    private function stopChannelSubscriber(array $subscriber): void
+    {
+        [$proc, $pipes] = $subscriber;
+
+        foreach ($pipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+
+        if (is_resource($proc)) {
+            proc_terminate($proc, SIGKILL);
+            proc_close($proc);
+        }
+    }
+}

--- a/tests/integration/RedisFailedJobProviderTest.php
+++ b/tests/integration/RedisFailedJobProviderTest.php
@@ -14,7 +14,6 @@
 namespace FoF\Redis\Tests\integration;
 
 use Flarum\Testing\integration\TestCase;
-use FoF\Redis\Extend\Redis;
 use FoF\Redis\Queue\RedisFailedJobProvider;
 use Illuminate\Contracts\Redis\Factory;
 use Illuminate\Queue\Failed\FailedJobProviderInterface;

--- a/tests/integration/RedisFailedJobProviderTest.php
+++ b/tests/integration/RedisFailedJobProviderTest.php
@@ -30,57 +30,15 @@ class RedisFailedJobProviderTest extends TestCase
     {
         parent::setUp();
 
-        // Use high, dedicated Redis databases for tests. A local dev stack may
-        // run a `queue:work` worker on the usual queue database, and keeps its
-        // cache/settings on low databases, all on the same Redis server. Tests
-        // that fell back onto those would consume the dev worker's jobs or
-        // overwrite the dev forum's live cache/settings. Databases 12-15 are
-        // reserved for the suite. Every service is pinned explicitly — an
-        // unpinned service falls back to the base `database`, which must never
-        // be a live one (see RedisTestConfig). (CI uses a dedicated Redis, so
-        // this is belt-and-suspenders there.)
-        $this->extend(
-            (new Redis($this->redisConfig()))
-                ->useDatabaseWith('cache', 13)
-                ->useDatabaseWith('queue', 14)
-                ->useDatabaseWith('session', 15)
-                ->useDatabaseWith('settings', 12)
-        );
-
-        // Start from a clean queue database. Tests share one Redis instance, so
-        // residue from a previous test would otherwise skew the counts here.
-        $this->flushQueueDatabase();
+        $this->flushTestDatabases();
+        $this->registerRedis();
     }
 
     protected function tearDown(): void
     {
-        $this->flushQueueDatabase();
+        $this->flushTestDatabases();
 
         parent::tearDown();
-    }
-
-    protected function flushQueueDatabase(): void
-    {
-        // Flush directly via a raw client rather than through the container, so
-        // this does not boot the app before the test has finished registering.
-        try {
-            $config = $this->redisConfig();
-            $host = $config['host'];
-            $port = (int) $config['port'];
-
-            if (extension_loaded('redis')) {
-                $client = new \Redis();
-                $client->connect($host, $port);
-                $client->select(14); // the dedicated test queue database
-                $client->flushdb();
-                $client->close();
-            } else {
-                $client = new \Predis\Client(['scheme' => 'tcp', 'host' => $host, 'port' => $port, 'database' => 14]);
-                $client->flushdb();
-            }
-        } catch (\Throwable $e) {
-            // Redis not reachable — the test that needs it will fail loudly.
-        }
     }
 
     protected function failer(): RedisFailedJobProvider

--- a/tests/integration/RedisInfoCommandTest.php
+++ b/tests/integration/RedisInfoCommandTest.php
@@ -14,7 +14,6 @@
 namespace FoF\Redis\Tests\integration;
 
 use Flarum\Testing\integration\ConsoleTestCase;
-use FoF\Redis\Extend\Redis;
 use PHPUnit\Framework\Attributes\Test;
 
 class RedisInfoCommandTest extends ConsoleTestCase
@@ -25,19 +24,15 @@ class RedisInfoCommandTest extends ConsoleTestCase
     {
         parent::setUp();
 
-        // Use high, dedicated Redis databases for tests. A local dev stack
-        // keeps its cache/queue/session on low databases (1-3) of the same
-        // Redis server; tests that used those would clear the dev forum's live
-        // cache (its settings cache included, making extensions look disabled).
-        // Databases 12-15 are reserved for the suite. (CI uses a dedicated
-        // Redis, so this is belt-and-suspenders there.)
-        $this->extend(
-            (new Redis($this->redisConfig()))
-                ->useDatabaseWith('cache', 13)
-                ->useDatabaseWith('queue', 14)
-                ->useDatabaseWith('session', 15)
-                ->useDatabaseWith('settings', 12)
-        );
+        $this->flushTestDatabases();
+        $this->registerRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
     }
 
     #[Test]

--- a/tests/integration/RedisQueueStatsProviderTest.php
+++ b/tests/integration/RedisQueueStatsProviderTest.php
@@ -15,7 +15,6 @@ namespace FoF\Redis\Tests\integration;
 
 use Flarum\Queue\QueueStatsProvider;
 use Flarum\Testing\integration\TestCase;
-use FoF\Redis\Extend\Redis;
 use FoF\Redis\Queue\RedisQueueStatsProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -27,67 +26,15 @@ class RedisQueueStatsProviderTest extends TestCase
     {
         parent::setUp();
 
+        $this->flushTestDatabases();
         $this->registerRedis();
-
-        // Start from a clean queue database. Tests share one Redis instance, so
-        // residue from a previous test would otherwise skew the counts here.
-        $this->flushQueueDatabase();
-    }
-
-    /**
-     * Register the Redis extender. Tests share one Redis instance, so use high,
-     * dedicated databases (13-15): a local dev stack may run a `queue:work`
-     * worker on the usual queue database on the same server, which would
-     * consume the jobs these tests push and make assertions flaky. (CI uses a
-     * dedicated Redis with no worker, so this is belt-and-suspenders there.).
-     *
-     * @param array $queueConfig extra keys merged into the `queue` config block
-     */
-    protected function registerRedis(array $queueConfig = []): void
-    {
-        $config = $this->redisConfig();
-        $config['queue'] = array_merge($config['queue'] ?? [], $queueConfig);
-
-        $this->extend(
-            (new Redis($config))
-                ->useDatabaseWith('cache', 13)
-                ->useDatabaseWith('queue', 14)
-                ->useDatabaseWith('session', 15)
-                ->useDatabaseWith('settings', 12)
-        );
     }
 
     protected function tearDown(): void
     {
-        $this->flushQueueDatabase();
+        $this->flushTestDatabases();
 
         parent::tearDown();
-    }
-
-    protected function flushQueueDatabase(): void
-    {
-        // Flush directly via a raw client rather than through the container, so
-        // this does NOT boot the app. Booting here would lock in the extenders
-        // registered so far, preventing a test from registering extra queue
-        // config (which must happen before boot).
-        try {
-            $config = $this->redisConfig();
-            $host = $config['host'];
-            $port = (int) $config['port'];
-
-            if (extension_loaded('redis')) {
-                $client = new \Redis();
-                $client->connect($host, $port);
-                $client->select(14); // the dedicated test queue database
-                $client->flushdb();
-                $client->close();
-            } else {
-                $client = new \Predis\Client(['scheme' => 'tcp', 'host' => $host, 'port' => $port, 'database' => 14]);
-                $client->flushdb();
-            }
-        } catch (\Throwable $e) {
-            // Redis not reachable — a redis-dependent test will fail loudly.
-        }
     }
 
     protected function stats(): QueueStatsProvider

--- a/tests/integration/RedisServerInfoTest.php
+++ b/tests/integration/RedisServerInfoTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\RedisServerInfo;
+use PHPUnit\Framework\Attributes\Test;
+
+class RedisServerInfoTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->flushTestDatabases();
+        $this->registerRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
+    }
+
+    protected function info(): RedisServerInfo
+    {
+        return $this->app()->getContainer()->make(RedisServerInfo::class);
+    }
+
+    #[Test]
+    public function it_is_bound_as_a_singleton()
+    {
+        $this->assertInstanceOf(RedisServerInfo::class, $this->info());
+        $this->assertSame($this->info(), $this->info());
+    }
+
+    #[Test]
+    public function it_reads_the_server_section_without_error()
+    {
+        $info = $this->info();
+
+        $this->assertNotEmpty($info->section());
+        $this->assertFalse($info->hasError());
+        $this->assertNull($info->error());
+    }
+
+    #[Test]
+    public function it_reports_a_server_name_and_version()
+    {
+        $info = $this->info();
+
+        $this->assertContains($info->serverName(), ['Redis', 'Valkey']);
+        // A reachable server always yields a concrete version, never 'unknown'.
+        $this->assertNotSame('unknown', $info->version());
+        $this->assertMatchesRegularExpression('/^\d+\.\d+/', $info->version());
+    }
+
+    #[Test]
+    public function server_name_is_consistent_with_is_valkey()
+    {
+        $info = $this->info();
+
+        $this->assertSame($info->isValkey() ? 'Valkey' : 'Redis', $info->serverName());
+    }
+
+    #[Test]
+    public function it_reports_the_server_mode()
+    {
+        // Defaults to 'standalone' for a plain single-node server.
+        $this->assertSame('standalone', $this->info()->mode());
+    }
+
+    #[Test]
+    public function it_records_an_error_for_an_unreachable_server()
+    {
+        // Point at a port nothing is listening on; the INFO fetch must fail
+        // gracefully — hasError() true, section() empty, no exception thrown.
+        $manager = $this->app()->getContainer()->make(\FoF\Redis\Overrides\RedisManager::class);
+        $manager->addConnection('fof.unreachable', [
+            'host'     => '127.0.0.1',
+            'port'     => 6399, // no server here
+            'database' => 0,
+        ]);
+
+        $info = new RedisServerInfo($manager, 'fof.unreachable');
+
+        $this->assertSame([], $info->section());
+        $this->assertTrue($info->hasError());
+        $this->assertNotNull($info->error());
+        // Derived getters degrade gracefully rather than throwing.
+        $this->assertSame('unknown', $info->version());
+        $this->assertSame('standalone', $info->mode());
+    }
+}

--- a/tests/integration/RedisTestConfig.php
+++ b/tests/integration/RedisTestConfig.php
@@ -13,34 +13,127 @@
 
 namespace FoF\Redis\Tests\integration;
 
+use FoF\Redis\Extend\Redis;
+
 /**
- * Shared Redis connection config for integration tests.
+ * Shared Redis setup for integration tests.
  *
- * Points at a Redis-compatible server on 127.0.0.1:6379 by default, which is
- * exactly what the reusable backend CI workflow exposes when `enable_redis`
- * is set. Overridable via REDIS_HOST / REDIS_PORT for local runs.
+ * Points at a Redis-compatible server on 127.0.0.1:6379 by default (what the
+ * reusable backend CI workflow exposes when `enable_redis` is set); overridable
+ * via REDIS_HOST / REDIS_PORT for local runs.
+ *
+ * All services are pinned to dedicated high databases (12-15). This matters
+ * because tests may run against a Redis that is ALSO serving a live dev forum:
+ * a local dev stack keeps its cache/queue/session/settings on low databases
+ * and may run a `queue:work` worker. A test that used those databases would
+ * consume the worker's jobs or overwrite the dev forum's live data — flushing
+ * the settings cache once made a dev forum's extensions appear disabled. Every
+ * service is pinned here so no service can fall back onto a live database.
+ * (CI uses a dedicated Redis with no worker, so this is belt-and-suspenders
+ * there.)
  */
 trait RedisTestConfig
 {
+    protected int $testCacheDb = 13;
+    protected int $testQueueDb = 14;
+    protected int $testSessionDb = 15;
+    protected int $testSettingsDb = 12;
+
     protected function redisConfig(): array
     {
         return [
-            'host'        => getenv('REDIS_HOST') ?: '127.0.0.1',
-            'password'    => null,
-            'port'        => (int) (getenv('REDIS_PORT') ?: 6379),
-            // Base database for any service without an explicit useDatabaseWith
-            // override. Deliberately high: a local dev stack keeps its cache /
-            // settings on low databases (0-4) of the same Redis server, and a
-            // service that fell back to those would let tests overwrite the dev
-            // forum's live data (e.g. the settings cache). 12 is reserved for
-            // the suite, distinct from the queue/cache/session test databases.
-            'database'    => 12,
-            'prefix'      => '',
-            'pubsub'      => [
+            'host'     => getenv('REDIS_HOST') ?: '127.0.0.1',
+            'password' => null,
+            'port'     => (int) (getenv('REDIS_PORT') ?: 6379),
+            // Base database for any service without an explicit override. Kept
+            // high so an unpinned service can never land on a live database.
+            'database' => 12,
+            'prefix'   => '',
+            'pubsub'   => [
                 'enabled'   => true,
                 'autostart' => false,
             ],
             'persistent' => false,
         ];
+    }
+
+    /**
+     * Register the Redis extender with all services pinned to test databases.
+     *
+     * @param array $queueConfig extra keys merged into the `queue` config block
+     */
+    protected function registerRedis(array $queueConfig = []): void
+    {
+        $config = $this->redisConfig();
+        $config['queue'] = array_merge($config['queue'] ?? [], $queueConfig);
+
+        $this->extend(
+            (new Redis($config))
+                ->useDatabaseWith('cache', $this->testCacheDb)
+                ->useDatabaseWith('queue', $this->testQueueDb)
+                ->useDatabaseWith('session', $this->testSessionDb)
+                ->useDatabaseWith('settings', $this->testSettingsDb)
+        );
+    }
+
+    /**
+     * Flush the test databases via a raw client, WITHOUT booting the app.
+     *
+     * Going through the container would boot the application and lock in the
+     * extenders registered so far, which would stop a test from registering
+     * extra config (that must happen before boot). Using a raw client keeps
+     * the flush independent of app state, and never touches a live database.
+     */
+    protected function flushTestDatabases(): void
+    {
+        $config = $this->redisConfig();
+        $host = $config['host'];
+        $port = (int) $config['port'];
+        $databases = [$this->testCacheDb, $this->testQueueDb, $this->testSessionDb, $this->testSettingsDb];
+
+        try {
+            if (extension_loaded('redis')) {
+                $client = new \Redis();
+                $client->connect($host, $port);
+                foreach ($databases as $db) {
+                    $client->select($db);
+                    $client->flushdb();
+                }
+                $client->close();
+            } else {
+                foreach ($databases as $db) {
+                    (new \Predis\Client(['scheme' => 'tcp', 'host' => $host, 'port' => $port, 'database' => $db]))->flushdb();
+                }
+            }
+        } catch (\Throwable $e) {
+            // Redis not reachable — a redis-dependent test will fail loudly.
+        }
+    }
+
+    /**
+     * Open a raw client against a specific test database, matching the client
+     * fof/redis itself would select (phpredis when the extension is loaded,
+     * predis otherwise). Useful for asserting on stored data directly.
+     *
+     * @return \Redis|\Predis\Client
+     */
+    protected function rawRedis(int $database)
+    {
+        $config = $this->redisConfig();
+
+        if (extension_loaded('redis')) {
+            $client = new \Redis();
+            $client->connect($config['host'], (int) $config['port']);
+            $client->select($database);
+
+            return $client;
+        }
+
+        return new \Predis\Client([
+            'scheme'   => 'tcp',
+            'host'     => $config['host'],
+            'port'     => (int) $config['port'],
+            'database' => $database,
+        ]);
     }
 }

--- a/tests/integration/SessionTest.php
+++ b/tests/integration/SessionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Session\RedisSessionHandler;
+use PHPUnit\Framework\Attributes\Test;
+use SessionHandlerInterface;
+
+class SessionTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->flushTestDatabases();
+        $this->registerRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
+    }
+
+    protected function handler(): SessionHandlerInterface
+    {
+        return $this->app()->getContainer()->make(SessionHandlerInterface::class);
+    }
+
+    #[Test]
+    public function the_session_handler_is_the_redis_handler()
+    {
+        $this->assertInstanceOf(RedisSessionHandler::class, $this->handler());
+    }
+
+    #[Test]
+    public function session_data_round_trips_through_redis()
+    {
+        $handler = $this->handler();
+        $id = 'fof-redis-session-'.bin2hex(random_bytes(8));
+
+        $this->assertTrue($handler->write($id, 'the-session-payload'));
+        $this->assertSame('the-session-payload', $handler->read($id));
+
+        $this->assertTrue($handler->destroy($id));
+        // A read after destroy returns an empty string (the SessionHandler
+        // contract), never the old payload.
+        $this->assertSame('', $handler->read($id));
+    }
+
+    #[Test]
+    public function session_data_lands_in_the_session_redis_database()
+    {
+        $handler = $this->handler();
+        $id = 'fof-redis-session-raw-'.bin2hex(random_bytes(8));
+        $handler->write($id, 'stored-in-redis');
+
+        $raw = $this->rawRedis($this->testSessionDb);
+        $keys = $raw->keys('*'.$id.'*');
+
+        $this->assertNotEmpty($keys, 'session data should be stored in the Redis session database');
+    }
+
+    #[Test]
+    public function the_handler_survives_serialization()
+    {
+        // The handler holds a cache repository that is not serialisable, so it
+        // implements __sleep/__wakeup to drop and re-resolve it. A worker that
+        // serialises the session handler (e.g. across a queue boundary) must
+        // get a working handler back.
+        $handler = $this->handler();
+
+        $restored = unserialize(serialize($handler));
+
+        $this->assertInstanceOf(RedisSessionHandler::class, $restored);
+
+        // And it still functions after the round-trip.
+        $id = 'fof-redis-session-wake-'.bin2hex(random_bytes(8));
+        $this->assertTrue($restored->write($id, 'after-wakeup'));
+        $this->assertSame('after-wakeup', $restored->read($id));
+    }
+}

--- a/tests/integration/SettingsTest.php
+++ b/tests/integration/SettingsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Foundation\Event\ClearingCache;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Settings\RedisCacheSettingsRepository;
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPUnit\Framework\Attributes\Test;
+
+class SettingsTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->flushTestDatabases();
+        $this->registerRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
+    }
+
+    protected function settings(): SettingsRepositoryInterface
+    {
+        return $this->app()->getContainer()->make(SettingsRepositoryInterface::class);
+    }
+
+    /**
+     * The Redis-backed cache layer for settings.
+     */
+    protected function settingsCache()
+    {
+        return $this->app()->getContainer()->make('cache.settings');
+    }
+
+    #[Test]
+    public function the_settings_repository_is_backed_by_the_redis_cache_layer()
+    {
+        // The bound repository wraps RedisCacheSettingsRepository somewhere in
+        // its decorator chain; a plain string read should still work.
+        $settings = $this->settings();
+
+        $settings->set('fof-redis.probe', 'hello');
+        $this->assertSame('hello', $settings->get('fof-redis.probe'));
+    }
+
+    #[Test]
+    public function reading_settings_populates_the_redis_cache()
+    {
+        // Target the Redis layer directly: in the full chain a per-request
+        // MemoryCacheSettingsRepository sits in front of it, so once the app
+        // has read settings during boot the memory layer would answer without
+        // ever touching Redis. This asserts the Redis layer's own fill.
+        $inner = $this->app()->getContainer()->make(\Flarum\Settings\DatabaseSettingsRepository::class);
+        $repo = new RedisCacheSettingsRepository($inner, $this->settingsCache());
+
+        $this->settingsCache()->forget('flarum:settings');
+        $this->assertFalse($this->settingsCache()->has('flarum:settings'));
+
+        $all = $repo->all();
+
+        $this->assertIsArray($all);
+        $this->assertTrue($this->settingsCache()->has('flarum:settings'));
+        $this->assertIsArray($this->settingsCache()->get('flarum:settings'));
+    }
+
+    #[Test]
+    public function set_updates_the_cached_array_in_place()
+    {
+        // Warm the cache.
+        $this->settings()->all();
+        $this->assertIsArray($this->settingsCache()->get('flarum:settings'));
+
+        // Setting a value patches the cached array rather than dropping it,
+        // so a stale read-replica cannot re-populate an old value.
+        $this->settings()->set('fof-redis.inplace', 'patched');
+
+        $cached = $this->settingsCache()->get('flarum:settings');
+        $this->assertArrayHasKey('fof-redis.inplace', $cached);
+        $this->assertSame('patched', $cached['fof-redis.inplace']);
+    }
+
+    #[Test]
+    public function delete_removes_the_key_from_the_cached_array_in_place()
+    {
+        $this->settings()->set('fof-redis.temp', 'value');
+        $this->settings()->all();
+        $this->assertArrayHasKey('fof-redis.temp', $this->settingsCache()->get('flarum:settings'));
+
+        $this->settings()->delete('fof-redis.temp');
+
+        $cached = $this->settingsCache()->get('flarum:settings');
+        $this->assertIsArray($cached);
+        $this->assertArrayNotHasKey('fof-redis.temp', $cached);
+    }
+
+    #[Test]
+    public function clearing_cache_event_invalidates_the_settings_cache()
+    {
+        $this->settings()->all();
+        $this->assertTrue($this->settingsCache()->has('flarum:settings'));
+
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(new ClearingCache());
+
+        $this->assertFalse(
+            $this->settingsCache()->has('flarum:settings'),
+            'the ClearingCache event should forget the Redis settings cache'
+        );
+    }
+
+    #[Test]
+    public function all_guards_against_reentrant_calls()
+    {
+        // The RedisCacheSettingsRepository sets a $loading flag while filling
+        // the cache and returns [] to a re-entrant all() call, preventing the
+        // infinite recursion that a DB event reading settings mid-query would
+        // otherwise cause. Drive that directly with a fake inner repository
+        // that calls back into all() while being read.
+        $cache = $this->settingsCache();
+        $cache->forget('flarum:settings');
+
+        $inner = new class() implements SettingsRepositoryInterface {
+            public ?RedisCacheSettingsRepository $outer = null;
+            public int $reentrantResult = -1;
+
+            public function all(): array
+            {
+                // Re-enter while the outer repository is mid-fill.
+                $this->reentrantResult = count($this->outer->all());
+
+                return ['committed' => '1'];
+            }
+
+            public function get(string $key, $default = null): mixed
+            {
+                return $default;
+            }
+
+            public function set(string $key, $value): void
+            {
+            }
+
+            public function delete(string $key): void
+            {
+            }
+        };
+
+        $repo = new RedisCacheSettingsRepository($inner, $cache);
+        $inner->outer = $repo;
+
+        $result = $repo->all();
+
+        // The re-entrant call returned early with [] instead of recursing.
+        $this->assertSame(0, $inner->reentrantResult);
+        // The outer call still produced the real value.
+        $this->assertSame(['committed' => '1'], $result);
+    }
+}

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+>
+    <source>
+        <include>
+            <directory suffix=".php">../src/</directory>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="FoF Redis Unit Tests">
+            <directory suffix="Test.php">./unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/unit/ConfigurationTest.php
+++ b/tests/unit/ConfigurationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\unit;
+
+use FoF\Redis\Configuration;
+use FoF\Redis\Provides\Cache;
+use FoF\Redis\Provides\Queue;
+use FoF\Redis\Provides\Session;
+use FoF\Redis\Provides\Settings;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    private function baseConfig(): array
+    {
+        return [
+            'host'     => '127.0.0.1',
+            'port'     => 6379,
+            'password' => null,
+            'database' => 1,
+        ];
+    }
+
+    #[Test]
+    public function make_accepts_an_array()
+    {
+        $config = Configuration::make($this->baseConfig());
+
+        $this->assertSame('127.0.0.1', $config->toArray()['host']);
+    }
+
+    #[Test]
+    public function make_rejects_a_non_existent_file_path()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Configuration::make('/does/not/exist.php');
+    }
+
+    #[Test]
+    public function for_falls_back_to_the_base_database_when_not_overridden()
+    {
+        $config = Configuration::make($this->baseConfig());
+
+        $this->assertSame(1, $config->for('cache')->toArray()['database']);
+    }
+
+    #[Test]
+    public function use_database_with_overrides_the_database_per_service()
+    {
+        $config = Configuration::make($this->baseConfig())
+            ->useDatabaseWith('cache', 2)
+            ->useDatabaseWith('queue', 3);
+
+        $this->assertSame(2, $config->for('cache')->toArray()['database']);
+        $this->assertSame(3, $config->for('queue')->toArray()['database']);
+        // A service without an override still gets the base database.
+        $this->assertSame(1, $config->for('session')->toArray()['database']);
+    }
+
+    #[Test]
+    public function for_uses_a_per_service_connection_block_when_present()
+    {
+        $config = Configuration::make([
+            'connections' => [
+                'cache' => ['host' => 'cache.example', 'port' => 6380, 'database' => 5],
+                'queue' => ['host' => 'queue.example', 'port' => 6381, 'database' => 6],
+            ],
+        ]);
+
+        $cache = $config->for('cache')->toArray();
+        $this->assertSame('cache.example', $cache['host']);
+        $this->assertSame(6380, $cache['port']);
+        $this->assertSame(5, $cache['database']);
+
+        $queue = $config->for('queue')->toArray();
+        $this->assertSame('queue.example', $queue['host']);
+    }
+
+    #[Test]
+    public function use_database_with_overrides_a_per_service_connection_block_database()
+    {
+        $config = Configuration::make([
+            'connections' => [
+                'cache' => ['host' => 'cache.example', 'database' => 5],
+            ],
+        ])->useDatabaseWith('cache', 9);
+
+        $this->assertSame(9, $config->for('cache')->toArray()['database']);
+    }
+
+    #[Test]
+    public function for_drops_an_empty_password()
+    {
+        $config = Configuration::make($this->baseConfig()); // password => null
+
+        $this->assertArrayNotHasKey('password', $config->for('cache')->toArray());
+    }
+
+    #[Test]
+    public function for_keeps_a_real_password()
+    {
+        $config = Configuration::make(array_merge($this->baseConfig(), ['password' => 'secret']));
+
+        $this->assertSame('secret', $config->for('cache')->toArray()['password']);
+    }
+
+    #[Test]
+    public function all_services_are_enabled_by_default()
+    {
+        $enabled = Configuration::make($this->baseConfig())->enabled();
+
+        $this->assertSame(Cache::class, $enabled['cache']);
+        $this->assertSame(Queue::class, $enabled['queue']);
+        $this->assertSame(Session::class, $enabled['session']);
+        $this->assertSame(Settings::class, $enabled['settings']);
+    }
+
+    #[Test]
+    public function disable_removes_services()
+    {
+        $enabled = Configuration::make($this->baseConfig())
+            ->disable(['cache', 'session'])
+            ->enabled();
+
+        $this->assertArrayNotHasKey('cache', $enabled);
+        $this->assertArrayNotHasKey('session', $enabled);
+        $this->assertArrayHasKey('queue', $enabled);
+        $this->assertArrayHasKey('settings', $enabled);
+    }
+}


### PR DESCRIPTION
Backend tests until now covered only the queue service (failer, stats, named queues). This extends coverage to the whole extension — **cache, session, settings, and the configuration/wiring layer** — across **both** the phpredis and predis clients.

## What's covered

**Settings** (`SettingsTest`) — the Redis-backed settings repository:
- reads fill the Redis cache from the database;
- `set()`/`delete()` patch the cached array in place (the read-replica-split safeguard);
- the `ClearingCache` event invalidates the cache;
- the **re-entrancy guard** in `all()` that prevents the infinite recursion a DB event reading settings mid-fill would otherwise cause (verified by mutation — removing the guard makes the test recurse and die).

**Cache** (`CacheTest`) — the store resolves to a Redis store (and the `Store` alias), values round-trip and are confirmed present in the cache database, `CacheConnectionReady` dispatches, and a cache clear publishes on the invalidation channel (asserted with a background subscriber; stable across repeated runs).

**Session** (`SessionTest`) — the handler is the Redis handler, sessions round-trip and land in the session database, and the handler **survives serialization** (its `__sleep`/`__wakeup` drops and re-resolves the non-serialisable cache repository).

**Server info** (`RedisServerInfoTest`) — server name / version / mode / Valkey detection, and graceful degradation for an unreachable server (no exception; `hasError()`; `'unknown'`/`'standalone'` fallbacks).

**Bindings & extender** (`BindingsTest`) — `RedisManager` bound and aliased to the `Factory` contract, the client matches the environment, a `disable()`d service is not overridden, and the extender chains configuration calls through `__call`.

**Configuration** (`ConfigurationTest`, new **unit** suite) — `for()` connection resolution, per-service `connections` blocks, `useDatabaseWith` precedence, the base-`database` fallback, password handling, and service enable/disable. Pure logic, so it runs as a fast unit suite (no Redis, no process isolation).

## Test isolation

Shared Redis setup is centralised in the `RedisTestConfig` trait: all services are pinned to dedicated databases (12–15), flushing uses a raw client, and a matching-client helper reads stored data directly. This keeps the suite isolated from a Redis that may also be serving a live forum (a mis-pinned test previously flushed a dev forum's settings cache). The existing queue tests are migrated onto the trait, so the isolation can't drift per-file again.

## Results

59 tests (10 unit + 49 integration), green under **both** phpredis and predis; phpstan clean.