### PR TITLE
[2.x] fix: session handler using the wrong Redis store after serialization

### DIFF
--- a/src/Session/RedisSessionHandler.php
+++ b/src/Session/RedisSessionHandler.php
@@ -13,6 +13,7 @@
 
 namespace FoF\Redis\Session;
 
+use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Session\CacheBasedSessionHandler;
 
 class RedisSessionHandler extends CacheBasedSessionHandler
@@ -24,6 +25,12 @@ class RedisSessionHandler extends CacheBasedSessionHandler
 
     public function __wakeup(): void
     {
-        $this->cache = resolve('cache.store');
+        // Re-resolve the SESSION store (dropped by __sleep because the Redis
+        // client isn't serialisable), not the general cache store. Resolving
+        // `cache.store` here would make a woken handler read and write sessions
+        // in the cache database — wrong whenever sessions and cache are pinned
+        // to different Redis databases. Rebuild the same repository the Session
+        // provider wraps around `session.redisstore`.
+        $this->cache = new CacheRepository(resolve('session.redisstore'));
     }
 }

--- a/src/Settings/RedisCacheSettingsRepository.php
+++ b/src/Settings/RedisCacheSettingsRepository.php
@@ -63,10 +63,11 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
     {
         $this->inner->set($key, $value);
 
-        // Update the cache in-place to avoid a stale read-replica re-populating it.
-        // Environments with a read/write DB split (no `sticky` connection) would
-        // otherwise re-read the old value from the replica after forget().
-        // If the cache is cold, drop it entirely so the next all() re-builds from DB.
+        // Patch the cached array in place so a warm cache reflects the new value
+        // without re-reading the database — which, on a read/write split with no
+        // `sticky` connection, could otherwise re-populate a stale value from a
+        // lagging replica. If the cache is cold there is nothing to patch; the
+        // next all() rebuilds it from the database on its own.
         $all = $this->cache->get($this->cacheKey);
 
         if (is_array($all)) {

--- a/tests/integration/SessionTest.php
+++ b/tests/integration/SessionTest.php
@@ -94,4 +94,32 @@ class SessionTest extends TestCase
         $this->assertTrue($restored->write($id, 'after-wakeup'));
         $this->assertSame('after-wakeup', $restored->read($id));
     }
+
+    #[Test]
+    public function a_woken_handler_still_uses_the_session_database()
+    {
+        // __wakeup must re-resolve the SESSION store, not the general cache
+        // store. When cache and session are pinned to different Redis
+        // databases (as the README recommends), a handler that woke up onto
+        // the cache database would read/write sessions in the wrong place —
+        // sessions written before serialization would vanish afterwards.
+        $restored = unserialize(serialize($this->handler()));
+
+        $id = 'fof-redis-session-db-'.bin2hex(random_bytes(8));
+        $restored->write($id, 'must-be-in-session-db');
+
+        // The session data must land in the session database...
+        $sessionDb = $this->rawRedis($this->testSessionDb);
+        $this->assertNotEmpty(
+            $sessionDb->keys('*'.$id.'*'),
+            'a woken session handler should write to the session database'
+        );
+
+        // ...and NOT in the cache database.
+        $cacheDb = $this->rawRedis($this->testCacheDb);
+        $this->assertEmpty(
+            $cacheDb->keys('*'.$id.'*'),
+            'a woken session handler must not write sessions to the cache database'
+        );
+    }
 }


### PR DESCRIPTION
## The bug

`RedisSessionHandler` extends `CacheBasedSessionHandler`, which holds a cache repository backed by the **session** Redis store. Because the underlying Redis client isn't serialisable, the handler implements `__sleep`/`__wakeup` to drop and rebuild that repository. `__wakeup` rebuilt it from the wrong binding:

```php
$this->cache = resolve('cache.store');   // the general CACHE store
```

The Session provider builds the live handler around `session.redisstore` (the **session** connection), so after any serialize → unserialize round-trip the handler switched to operating on the **cache** database.

When sessions and cache share one Redis database this is invisible. But the README specifically recommends splitting services across databases (`useDatabaseWith('cache', 1)`, `useDatabaseWith('session', 3)`, …) — and in that setup a woken handler reads and writes sessions in the cache database. Sessions written before serialization become invisible after it.

Proven directly: write through a fresh handler → lands in the session DB; serialize/unserialize, write again → lands in the **cache** DB.

## The fix

`__wakeup` now rebuilds the repository around the session store, matching how the provider constructs the handler:

```php
$this->cache = new CacheRepository(resolve('session.redisstore'));
```

A new test asserts a woken handler writes to the session database and **not** the cache database. It fails against the old code and passes with the fix, under both the phpredis and predis clients.

## Also included

A one-line comment correction in `RedisCacheSettingsRepository::set()`: it claimed a cold cache is dropped "entirely", but the code actually no-ops when the cache is cold. That is safe (the next `all()` rebuilds from the database), so only the comment was misleading — no behaviour change.

## Results

10 unit + 50 integration tests green under both phpredis and predis; phpstan clean.

Found while adding complete service coverage (#25) — the coverage there confirmed the handler *functioned* after serialization, but only because it read back through the same wrong store; this asserts the correct store.