### PR TITLE
[2.x] fix: queue-dashboard bugs under Redis: failed_at format and delayed-job count

### DIFF
--- a/src/Queue/RedisFailedJobProvider.php
+++ b/src/Queue/RedisFailedJobProvider.php
@@ -91,7 +91,13 @@ class RedisFailedJobProvider implements CountableFailedJobProvider, FailedJobPro
             'queue'      => $queue,
             'payload'    => $payload,
             'exception'  => (string) mb_convert_encoding((string) $exception, 'UTF-8'),
-            'failed_at'  => $failedAt->getTimestamp(),
+            // Store a date STRING, not a unix timestamp: core's failed-job UI
+            // renders this with `new Date(failed_at)`, and a bare integer string
+            // (which phpredis returns from the hash) parses to Invalid Date in
+            // JS. ISO-8601 matches the datetime the database failer produces and
+            // is unambiguously parseable. (The sorted-set index below keeps the
+            // numeric timestamp for ordering and prune-by-age.)
+            'failed_at'  => $failedAt->toIso8601String(),
         ]);
 
         // A TTL bounds memory growth and, under a volatile-* eviction policy,

--- a/src/Queue/RedisQueueStatsProvider.php
+++ b/src/Queue/RedisQueueStatsProvider.php
@@ -74,13 +74,21 @@ class RedisQueueStatsProvider implements QueueStatsProvider
     }
 
     /**
-     * Jobs waiting to be picked up (the queue list).
+     * Jobs that are queued but not yet reserved by a worker.
+     *
+     * This counts both the ready list AND the delayed set, to match core's
+     * DatabaseQueueStatsProvider, which counts every `queue_jobs` row with a
+     * NULL `reserved_at` as pending — delayed jobs included (they sit in the
+     * same table with a future `available_at`). Counting only the ready list
+     * (llen) would report an idle queue while jobs are scheduled for later.
      */
     protected function pendingSize(string $queue): int
     {
-        return $this->queue instanceof RedisQueue
-            ? (int) $this->queue->pendingSize($queue)
-            : 0;
+        if (! $this->queue instanceof RedisQueue) {
+            return 0;
+        }
+
+        return (int) $this->queue->pendingSize($queue) + (int) $this->queue->delayedSize($queue);
     }
 
     /**

--- a/src/Queue/RedisQueueStatsProvider.php
+++ b/src/Queue/RedisQueueStatsProvider.php
@@ -84,7 +84,7 @@ class RedisQueueStatsProvider implements QueueStatsProvider
      */
     protected function pendingSize(string $queue): int
     {
-        if (! $this->queue instanceof RedisQueue) {
+        if (!$this->queue instanceof RedisQueue) {
             return 0;
         }
 

--- a/tests/integration/RedisFailedJobProviderTest.php
+++ b/tests/integration/RedisFailedJobProviderTest.php
@@ -60,6 +60,36 @@ class RedisFailedJobProviderTest extends TestCase
     }
 
     #[Test]
+    public function failed_at_is_a_parseable_date_string_not_a_unix_timestamp()
+    {
+        // The admin failed-jobs UI renders failed_at with `new Date(job.failed_at)`
+        // (core FailedJobsModal). A bare unix-seconds value — which phpredis
+        // returns from the hash as a numeric string like "1753358400" — parses
+        // to `Invalid Date` in JS. The DB failer stores a datetime string, so
+        // the Redis failer must match: failed_at has to be a date string that
+        // JS `Date` can parse, not a plain integer.
+        $failer = $this->failer();
+        $id = $failer->log('redis', 'default', $this->payload('date-check'), new \RuntimeException('x'));
+
+        $failedAt = $failer->find($id)->failed_at;
+
+        // Must NOT be a bare all-digits unix timestamp.
+        $this->assertDoesNotMatchRegularExpression(
+            '/^\d+$/',
+            (string) $failedAt,
+            'failed_at must not be a bare unix timestamp (JS `new Date()` cannot parse it)'
+        );
+        // Must be parseable as a real date (strtotime mirrors JS Date parsing
+        // closely enough for the ISO-8601 / datetime forms we care about).
+        $ts = strtotime((string) $failedAt);
+        $this->assertNotFalse($ts, "failed_at '$failedAt' is not a parseable date string");
+        // And it should be recent (within the last minute), i.e. it really is
+        // the failure time, not an epoch/garbage value.
+        $this->assertGreaterThan(time() - 60, $ts);
+        $this->assertLessThanOrEqual(time() + 60, $ts);
+    }
+
+    #[Test]
     public function it_logs_and_finds_a_failed_job_with_the_expected_shape()
     {
         $failer = $this->failer();

--- a/tests/integration/RedisQueueStatsProviderTest.php
+++ b/tests/integration/RedisQueueStatsProviderTest.php
@@ -92,6 +92,33 @@ class RedisQueueStatsProviderTest extends TestCase
     }
 
     #[Test]
+    public function delayed_jobs_are_counted_as_pending()
+    {
+        // Core's DatabaseQueueStatsProvider counts every not-yet-reserved job
+        // as pending — including delayed ones, which sit in queue_jobs with a
+        // future available_at and NULL reserved_at. The Redis provider must
+        // match: a delayed job (in the ':delayed' zset) has to show up in
+        // pending, otherwise the dashboard reports an idle queue while jobs are
+        // scheduled. Counting only the ready list (llen) misses them.
+        $queue = $this->app()->getContainer()->make('flarum.queue.connection');
+
+        // One ready now (ready list)...
+        $queue->pushRaw(json_encode(['uuid' => 'ready', 'displayName' => 'X']), 'default');
+        // ...and two scheduled for later. A delayed job lives in the
+        // 'queues:default:delayed' sorted set, scored by its available-at time
+        // (exactly what RedisQueue::laterRaw writes). Insert them directly since
+        // laterRaw is protected.
+        $raw = $this->rawRedis($this->testQueueDb);
+        $availableAt = time() + 3600;
+        $raw->zadd('queues:default:delayed', $availableAt, json_encode(['uuid' => 'later-1', 'displayName' => 'X']));
+        $raw->zadd('queues:default:delayed', $availableAt, json_encode(['uuid' => 'later-2', 'displayName' => 'X']));
+
+        $totals = $this->stats()->totals();
+        $this->assertSame(3, $totals['pending'], 'pending must include the 1 ready + 2 delayed jobs');
+        $this->assertSame(3, $this->stats()->queues()['default']['pending']);
+    }
+
+    #[Test]
     public function configured_named_queues_are_registered_and_reported()
     {
         // A site that runs `queue:work --queue=emails,default` declares those


### PR DESCRIPTION
Two user-visible bugs in how the Redis queue feeds core's queue dashboard — both diverge from the database queue the shared core UI was built against. Found during an adversarial correctness review; each is reproduced by a test that fails against the old code.

## 1. Failed jobs show "Invalid Date"

`RedisFailedJobProvider::log()` stored `failed_at` as a unix timestamp (`getTimestamp()`). phpredis returns hash fields as **strings**, so the value reached the admin failed-jobs UI as e.g. `"1785254061"`, and the UI renders it with `new Date(job.failed_at)` — which parses a bare integer string to **`Invalid Date`** (verified: `new Date("1785254061")` → `Invalid Date`).

Fix: store an **ISO-8601 string**, matching the datetime the database failer (`DatabaseUuidFailedJobProvider`) produces. The sorted-set index keeps the numeric timestamp, so ordering and prune-by-age are unaffected.

## 2. Delayed jobs are invisible on the dashboard

`RedisQueueStatsProvider` counted only the ready list (`pendingSize()` = `llen`) as pending. Delayed jobs live in the `:delayed` sorted set and were counted nowhere — so an operator with jobs scheduled for later saw an **idle queue**.

Core's `DatabaseQueueStatsProvider` counts every not-yet-reserved job as pending, and delayed jobs sit in `queue_jobs` with a future `available_at` and `NULL reserved_at` — i.e. they **are** counted as pending there. Fix: add `delayedSize()` to the pending total so the Redis dashboard matches (verified: 1 ready + 2 delayed now reports pending=3, was 1).

## Tests / results

New tests assert a JS-parseable `failed_at` and that delayed jobs count as pending; both fail against the old behaviour and pass with the fix. Full suite green under **both** phpredis and predis (10 unit + 52 integration); phpstan clean.