### PR TITLE
[2.x] fix: settings-cache desync, server info on cache-disabled installs, and lost config prefix

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -61,10 +61,17 @@ class Configuration
     {
         $config = $this->config;
 
-        // In case the configuration contains a `connections` key, we'll use that.
+        // A per-service `connections.<service>` block overrides connection
+        // details for that service. Merge it OVER the top-level config rather
+        // than replacing wholesale, so shared top-level keys (e.g. `prefix`,
+        // `pubsub`) still apply — otherwise stores would be built with an empty
+        // prefix and keys would collide with other apps on the same Redis.
         if ($connection = Arr::get($config, "connections.$service")) {
-            $config = $connection;
+            $config = array_merge($config, $connection);
         }
+
+        // The `connections` map itself is not a connection parameter.
+        Arr::forget($config, 'connections');
 
         $useDatabase = Arr::get($this->databases, $service, $config['database'] ?? 0);
 

--- a/src/RedisServerInfo.php
+++ b/src/RedisServerInfo.php
@@ -97,8 +97,17 @@ class RedisServerInfo
             return $this->serverSection ?? [];
         }
 
+        $connection = $this->resolveConnectionName();
+
+        if ($connection === null) {
+            $this->error = 'No Redis connection is registered.';
+            $this->serverSection = [];
+
+            return $this->serverSection;
+        }
+
         try {
-            $info = $this->redis->connection($this->connection)->info('server');
+            $info = $this->redis->connection($connection)->info('server');
             // Predis nests the section under a 'Server' key; phpredis returns flat.
             $this->serverSection = $info['Server'] ?? $info;
         } catch (\Exception $e) {
@@ -107,5 +116,30 @@ class RedisServerInfo
         }
 
         return $this->serverSection;
+    }
+
+    /**
+     * Pick a Redis connection that is actually registered.
+     *
+     * The default connection ('fof.cache') is only registered by the Cache
+     * provider; an install that disables cache but keeps other services would
+     * have no 'fof.cache' connection, leaving this stuck in an error state.
+     * Prefer the configured connection, then fall back to any other service
+     * connection that has been registered on the manager.
+     */
+    private function resolveConnectionName(): ?string
+    {
+        $candidates = array_values(array_unique(array_merge(
+            [$this->connection],
+            ['fof.cache', 'fof.sessions', 'fof.settings', 'default']
+        )));
+
+        foreach ($candidates as $name) {
+            if ($this->redis->getConnectionConfig($name) !== null) {
+                return $name;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Settings/RedisCacheSettingsRepository.php
+++ b/src/Settings/RedisCacheSettingsRepository.php
@@ -16,6 +16,7 @@ namespace FoF\Redis\Settings;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 
 class RedisCacheSettingsRepository implements SettingsRepositoryInterface
 {
@@ -24,6 +25,15 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
     protected string $cacheKey = 'flarum:settings';
     protected int $ttl = 3600; // 1 hour
     protected bool $loading = false;
+
+    /**
+     * The companion key `flexible()` writes alongside the value to record when
+     * the cache was last filled. Reads use it to decide staleness, so any
+     * in-place patch of the value must refresh it too, or the just-written
+     * value is judged stale and a background refresh clobbers it from the DB.
+     * Mirrors Illuminate\Cache\Repository::FLEXIBLE_CREATED_KEY_PREFIX.
+     */
+    protected string $createdKey = 'illuminate:cache:flexible:created:flarum:settings';
 
     public function __construct(SettingsRepositoryInterface $inner, CacheRepository $cache)
     {
@@ -72,7 +82,7 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
 
         if (is_array($all)) {
             $all[$key] = $value;
-            $this->cache->put($this->cacheKey, $all, $this->ttl);
+            $this->writeCache($all);
         }
     }
 
@@ -87,7 +97,19 @@ class RedisCacheSettingsRepository implements SettingsRepositoryInterface
 
         if (is_array($all)) {
             unset($all[$key]);
-            $this->cache->put($this->cacheKey, $all, $this->ttl);
+            $this->writeCache($all);
         }
+    }
+
+    /**
+     * Write the patched settings array back to the cache, keeping the
+     * `flexible()` created-timestamp in sync so the just-written value is
+     * treated as fresh rather than immediately stale (which would trigger a
+     * background DB refresh that could clobber it from a lagging replica).
+     */
+    protected function writeCache(array $all): void
+    {
+        $this->cache->put($this->cacheKey, $all, $this->ttl);
+        $this->cache->put($this->createdKey, Carbon::now()->getTimestamp(), $this->ttl);
     }
 }

--- a/tests/integration/BindingsTest.php
+++ b/tests/integration/BindingsTest.php
@@ -86,6 +86,32 @@ class BindingsTest extends TestCase
     }
 
     #[Test]
+    public function server_info_works_when_the_cache_service_is_disabled()
+    {
+        // RedisServerInfo is registered whenever ANY Redis service is enabled,
+        // but it defaults to the 'fof.cache' connection — which only the Cache
+        // provider registers. With cache disabled but other services on, a
+        // naive RedisServerInfo would query an unregistered connection and sit
+        // in a permanent error state, breaking `redis:info` on an otherwise
+        // healthy install. It must resolve against a connection that actually
+        // exists.
+        $this->flushTestDatabases();
+        $this->extend(
+            (new Redis($this->redisConfig()))
+                ->useDatabaseWith('queue', $this->testQueueDb)
+                ->useDatabaseWith('session', $this->testSessionDb)
+                ->useDatabaseWith('settings', $this->testSettingsDb)
+                ->disable(['cache'])
+        );
+
+        $info = $this->app()->getContainer()->make(\FoF\Redis\RedisServerInfo::class);
+
+        $this->assertNotEmpty($info->section(), 'server info should read INFO even with cache disabled');
+        $this->assertFalse($info->hasError(), 'server info must not be in an error state when cache is disabled: '.$info->error());
+        $this->assertNotSame('unknown', $info->version());
+    }
+
+    #[Test]
     public function the_extender_forwards_and_chains_configuration_calls()
     {
         // useDatabaseWith / disable are Configuration methods reached through

--- a/tests/integration/SettingsTest.php
+++ b/tests/integration/SettingsTest.php
@@ -100,6 +100,42 @@ class SettingsTest extends TestCase
     }
 
     #[Test]
+    public function set_keeps_the_flexible_created_timestamp_in_sync()
+    {
+        // all() stores via cache->flexible(), which writes TWO keys: the value
+        // and a companion 'illuminate:cache:flexible:created:flarum:settings'
+        // timestamp used to decide staleness. If set() patches only the value
+        // and leaves the created timestamp old, the next all() judges the
+        // freshly-set value STALE and defers a refresh from the database —
+        // which, on a lagging read replica, re-populates the OLD value,
+        // defeating the in-place patch's whole purpose. So set() must keep the
+        // created timestamp in sync with the value it writes.
+        $cache = $this->settingsCache();
+        $inner = $this->app()->getContainer()->make(\Flarum\Settings\DatabaseSettingsRepository::class);
+        $repo = new RedisCacheSettingsRepository($inner, $cache);
+        $createdKey = 'illuminate:cache:flexible:created:flarum:settings';
+
+        // Warm the cache (writes value + created).
+        $repo->all();
+
+        // Age the created timestamp into the stale window (ttl[0] = 3600-300 =
+        // 3300s), as if the cache had been filled ~an hour ago.
+        $cache->forever($createdKey, \Illuminate\Support\Carbon::now()->subSeconds(3400)->getTimestamp());
+
+        // Set a new value through the repo.
+        $repo->set('fof-redis.sync', 'fresh-value');
+
+        // The created timestamp must now be recent — NOT still in the stale
+        // window — so the value we just set is treated as fresh.
+        $created = (int) $cache->get($createdKey);
+        $this->assertGreaterThan(
+            \Illuminate\Support\Carbon::now()->subSeconds(3300)->getTimestamp(),
+            $created,
+            'set() must refresh the flexible created-timestamp so the new value is not immediately stale'
+        );
+    }
+
+    #[Test]
     public function delete_removes_the_key_from_the_cached_array_in_place()
     {
         $this->settings()->set('fof-redis.temp', 'value');

--- a/tests/unit/ConfigurationTest.php
+++ b/tests/unit/ConfigurationTest.php
@@ -91,6 +91,49 @@ class ConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function for_preserves_top_level_prefix_when_using_a_per_service_connection_block()
+    {
+        // Top-level keys like `prefix` (and `pubsub`) apply to all services.
+        // When a per-service `connections.<service>` block is used, for() must
+        // still carry those top-level keys through — otherwise every RedisStore
+        // is built with an empty prefix (Cache/Session/Settings providers read
+        // `prefix` off the resolved config), so keys are written unprefixed and
+        // collide with any other app sharing the Redis instance.
+        $config = Configuration::make([
+            'prefix'      => 'myapp:',
+            'pubsub'      => ['enabled' => true, 'channel' => 'myapp:invalidate'],
+            'connections' => [
+                'cache'   => ['host' => 'cache.example', 'database' => 5],
+                'session' => ['host' => 'session.example', 'database' => 6],
+            ],
+        ]);
+
+        $cache = $config->for('cache')->toArray();
+        $this->assertSame('cache.example', $cache['host'], 'per-service host still applies');
+        $this->assertSame('myapp:', $cache['prefix'] ?? null, 'top-level prefix must be preserved');
+        $this->assertSame('myapp:invalidate', $cache['pubsub']['channel'] ?? null, 'top-level pubsub must be preserved');
+
+        // A per-service key overrides the top-level one; absent per-service, the
+        // top-level value wins.
+        $session = $config->for('session')->toArray();
+        $this->assertSame('myapp:', $session['prefix'] ?? null);
+    }
+
+    #[Test]
+    public function a_per_service_block_can_override_a_top_level_key()
+    {
+        // If a service block sets its own prefix, that wins over the top-level.
+        $config = Configuration::make([
+            'prefix'      => 'global:',
+            'connections' => [
+                'cache' => ['host' => 'cache.example', 'prefix' => 'cacheonly:'],
+            ],
+        ]);
+
+        $this->assertSame('cacheonly:', $config->for('cache')->toArray()['prefix']);
+    }
+
+    #[Test]
     public function use_database_with_overrides_a_per_service_connection_block_database()
     {
         $config = Configuration::make([


### PR DESCRIPTION
Three correctness bugs surfaced by an adversarial review of the extension. Each is reproduced by a test that fails against the old behaviour and passes with the fix; the full suite is green under **both** phpredis and predis.

## 1. Settings cache desync (`RedisCacheSettingsRepository`)

`all()` caches via `cache->flexible()`, which writes **two** keys: the value (`flarum:settings`) and a companion `illuminate:cache:flexible:created:flarum:settings` timestamp that `flexible()` uses to decide staleness. `set()`/`delete()` patched only the value and left the timestamp untouched. Once the cache aged past the stale window, the next read judged the **just-written** value stale and deferred a background refresh from the database — which, on a read/write split with a lagging replica, re-populates the OLD value. That defeats the very in-place patch the code added to avoid stale replica reads.

Fix: `set()`/`delete()` now refresh the created timestamp alongside the value, so a freshly-written value is treated as fresh.

## 2. `RedisServerInfo` breaks when cache is disabled

`RedisServerInfo` is registered whenever *any* Redis service is enabled, but it defaulted to the `fof.cache` connection — which only the **Cache** provider registers. On an install that does `->disable(['cache'])` while keeping queue/session/settings, that connection never exists, so `section()` errored and stayed in a permanent error state: `redis:info` reported a broken server on an otherwise healthy install.

Fix: it now resolves the first *registered* connection among the service candidates (`fof.cache`, `fof.sessions`, `fof.settings`, `default`).

## 3. `Configuration::for()` drops top-level `prefix` / `pubsub`

When a per-service `connections.<service>` block was present, `for()` **replaced** the whole config with that block, discarding top-level keys like `prefix` and `pubsub`. Every `RedisStore` was then built with an empty prefix, so keys were written unprefixed — colliding with any other app sharing the Redis instance.

Fix: the per-service block is merged **over** the top-level config (per-service keys still win), and the internal `connections` map is no longer leaked into connection params.

## Results

12 unit + 52 integration tests green under phpredis and predis; phpstan clean. Reproduced each bug before fixing.