### PR TITLE
[2.x] fix: Fall back to the configured pub/sub channel in cache:subscribe

### DIFF
--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -75,13 +75,13 @@ class CacheSubscribeCommand extends AbstractCommand
      */
     public function resolveChannel(?string $option): string
     {
-        if (! empty($option)) {
+        if (!empty($option)) {
             return $option;
         }
 
         $configured = Arr::get($this->configuration->toArray(), 'pubsub.channel');
 
-        return ! empty($configured) ? $configured : self::DEFAULT_CHANNEL;
+        return !empty($configured) ? $configured : self::DEFAULT_CHANNEL;
     }
 
     protected function fire(): int

--- a/src/Console/CacheSubscribeCommand.php
+++ b/src/Console/CacheSubscribeCommand.php
@@ -16,26 +16,38 @@ namespace FoF\Redis\Console;
 use Flarum\Console\AbstractCommand;
 use Flarum\Foundation\Paths;
 use Flarum\Locale\LocaleManager;
+use FoF\Redis\Configuration;
 use FoF\Redis\Overrides\RedisManager;
 use Illuminate\Cache\Repository;
+use Illuminate\Support\Arr;
 use Predis\Connection\NodeConnectionInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputOption;
 
 class CacheSubscribeCommand extends AbstractCommand
 {
+    /**
+     * The well-known default channel, used only when neither --channel nor a
+     * configured pubsub.channel is present. Kept in sync with the publisher's
+     * default in the Cache provider.
+     */
+    public const DEFAULT_CHANNEL = 'flarum:cache:invalidate';
+
     protected Paths $paths;
     protected LocaleManager $locales;
     protected LoggerInterface $logger;
+    protected Configuration $configuration;
 
     public function __construct(
         Paths $paths,
         LocaleManager $locales,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        Configuration $configuration
     ) {
         $this->paths = $paths;
         $this->locales = $locales;
         $this->logger = $logger;
+        $this->configuration = $configuration;
         parent::__construct();
     }
 
@@ -46,7 +58,30 @@ class CacheSubscribeCommand extends AbstractCommand
             ->setDescription('Subscribe to Redis for distributed cache invalidation')
             ->addOption('once', null, InputOption::VALUE_NONE, 'Process one message and exit (for testing)')
             ->addOption('delay', null, InputOption::VALUE_REQUIRED, 'Delay in seconds before subscribing', 0)
-            ->addOption('channel', null, InputOption::VALUE_REQUIRED, 'Redis pub/sub channel', 'flarum:cache:invalidate');
+            // Default is null so an omitted option falls back to the CONFIGURED
+            // channel (see resolveChannel), not a hardcoded literal that could
+            // diverge from what the publisher uses.
+            ->addOption('channel', null, InputOption::VALUE_REQUIRED, 'Redis pub/sub channel', null);
+    }
+
+    /**
+     * Resolve the channel to subscribe on.
+     *
+     * Precedence: an explicit --channel wins; otherwise the configured
+     * pubsub.channel (the same value the publisher uses); otherwise the
+     * well-known default. This ensures a subscriber launched without --channel
+     * (e.g. from cron/systemd) listens on the same channel the publisher
+     * publishes to, rather than a hardcoded literal that ignores config.
+     */
+    public function resolveChannel(?string $option): string
+    {
+        if (! empty($option)) {
+            return $option;
+        }
+
+        $configured = Arr::get($this->configuration->toArray(), 'pubsub.channel');
+
+        return ! empty($configured) ? $configured : self::DEFAULT_CHANNEL;
     }
 
     protected function fire(): int
@@ -152,7 +187,7 @@ class CacheSubscribeCommand extends AbstractCommand
      */
     private function subscribePredis(\Predis\Client $client, string $podId): void
     {
-        $channel = (string) $this->input->getOption('channel');
+        $channel = $this->resolveChannel($this->input->getOption('channel'));
 
         $this->info('[Cache Subscriber] ✓ Connected (Predis)');
         $this->logger->info('[Cache Subscriber] Connected', ['client' => 'Predis', 'pod' => $podId]);
@@ -197,7 +232,7 @@ class CacheSubscribeCommand extends AbstractCommand
      */
     private function subscribePhpRedis(\Redis $client, string $podId): void
     {
-        $channel = (string) $this->input->getOption('channel');
+        $channel = $this->resolveChannel($this->input->getOption('channel'));
 
         $this->info('[Cache Subscriber] ✓ Connected (phpredis)');
         $this->logger->info('[Cache Subscriber] Connected', ['client' => 'phpredis', 'pod' => $podId]);

--- a/tests/integration/CacheSubscribeCommandTest.php
+++ b/tests/integration/CacheSubscribeCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use FoF\Redis\Console\CacheSubscribeCommand;
+use PHPUnit\Framework\Attributes\Test;
+
+class CacheSubscribeCommandTest extends ConsoleTestCase
+{
+    use RedisTestConfig;
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
+    }
+
+    protected function command(): CacheSubscribeCommand
+    {
+        return $this->app()->getContainer()->make(CacheSubscribeCommand::class);
+    }
+
+    #[Test]
+    public function without_an_explicit_channel_it_uses_the_configured_pubsub_channel()
+    {
+        // The publisher (Cache provider) publishes on the configured
+        // `pubsub.channel`. If the subscriber is launched without --channel
+        // (e.g. a cron/systemd unit running `flarum cache:subscribe`), it must
+        // fall back to that SAME configured channel — not a hardcoded literal —
+        // or it listens on a different channel and silently receives nothing.
+        $config = $this->redisConfig();
+        $config['pubsub'] = ['enabled' => true, 'channel' => 'myapp:custom:invalidate'];
+        $this->registerRedis();
+        // Re-register with the custom channel (registerRedis merges queue config
+        // only, so set the whole config here).
+        $this->extend(
+            (new \FoF\Redis\Extend\Redis($config))
+                ->useDatabaseWith('cache', $this->testCacheDb)
+                ->useDatabaseWith('queue', $this->testQueueDb)
+                ->useDatabaseWith('session', $this->testSessionDb)
+                ->useDatabaseWith('settings', $this->testSettingsDb)
+        );
+
+        $channel = $this->command()->resolveChannel(null);
+
+        $this->assertSame('myapp:custom:invalidate', $channel);
+    }
+
+    #[Test]
+    public function an_explicit_channel_option_wins_over_config()
+    {
+        $config = $this->redisConfig();
+        $config['pubsub'] = ['enabled' => true, 'channel' => 'myapp:custom:invalidate'];
+        $this->extend(
+            (new \FoF\Redis\Extend\Redis($config))
+                ->useDatabaseWith('cache', $this->testCacheDb)
+                ->useDatabaseWith('queue', $this->testQueueDb)
+                ->useDatabaseWith('session', $this->testSessionDb)
+                ->useDatabaseWith('settings', $this->testSettingsDb)
+        );
+
+        $this->assertSame('explicit:channel', $this->command()->resolveChannel('explicit:channel'));
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_default_channel_when_none_is_configured()
+    {
+        // No pubsub.channel configured → the well-known default.
+        $this->registerRedis();
+
+        $this->assertSame('flarum:cache:invalidate', $this->command()->resolveChannel(null));
+    }
+}


### PR DESCRIPTION
## The bug

`cache:subscribe`'s `--channel` option defaulted to a hardcoded `flarum:cache:invalidate` literal, independent of configuration. The publisher (the Cache provider's `ClearingCache` listener) publishes on the **configured** `pubsub.channel`. Autostart forwards that value with `--channel`, so the autostarted path is fine — but a subscriber launched **without** `--channel` (a cron or systemd unit running `flarum cache:subscribe`, which the command's own "retry on next cron trigger" note points at) would listen on the hardcoded default while the publisher used a custom channel.

Redis silently drops published messages that have no subscriber on the target channel (`PUBLISH` returns 0, ignored), so cross-pod cache invalidation would just stop working with **no error anywhere**.

## The fix

Inject the `Configuration` and resolve the channel with clear precedence:

1. explicit `--channel` if given,
2. otherwise the configured `pubsub.channel` (the same value the publisher uses),
3. otherwise the well-known default.

The subscriber now always listens on the channel the publisher publishes to.

## Tests

New `CacheSubscribeCommandTest` covers all three precedence cases (configured channel used when no option; explicit option wins; default when nothing configured). Full suite green under phpredis and predis; phpstan clean.

## Not included (follow-up)

The same review flagged spawn-lock lifecycle issues in the subscriber's autostart helper (a `'0'` PID sentinel that can wedge spawning after a failed start; the spawn lock being released before the daemon writes its PID; a non-atomic lock-file write). Those are real but are timing/concurrency races that resist deterministic testing, so they're tracked separately for a considered refactor rather than bundled here.