### PR TITLE
[2.x] fix: count queue stats through core's RoutingQueue wrapper

### DIFF
--- a/src/Queue/RedisQueueStatsProvider.php
+++ b/src/Queue/RedisQueueStatsProvider.php
@@ -14,6 +14,7 @@
 namespace FoF\Redis\Queue;
 
 use Flarum\Queue\QueueStatsProvider;
+use Flarum\Queue\RoutingQueue;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\Failed\FailedJobProviderInterface;
 use Illuminate\Queue\RedisQueue;
@@ -28,18 +29,53 @@ use Illuminate\Queue\RedisQueue;
  *
  * Counts come from the Redis queue's own public size methods (which speak to
  * Redis via the configured client, so they work under both phpredis and
- * predis). Failed jobs are read through the bound failer, exactly as core does
- * — fof/redis does not register its own failer, so failures still live in the
- * `queue_failed_jobs` table.
+ * predis). Since Flarum 2.0.0-rc.6, core decorates `flarum.queue.connection`
+ * with a {@see RoutingQueue} wrapper, so the injected queue is unwrapped to the
+ * concrete driver before those methods are reached — the same way core's own
+ * QueueServiceProvider and ApplicationInfoProvider see through it.
+ *
+ * Failed jobs are read through the bound failer, exactly as core does — under
+ * fof/redis that is our own RedisFailedJobProvider, so failures live in Redis
+ * rather than the `queue_failed_jobs` table.
  */
 class RedisQueueStatsProvider implements QueueStatsProvider
 {
+    /**
+     * The concrete queue driver, with any core wrapper unwrapped.
+     */
+    protected Queue $driver;
+
     public function __construct(
         protected Queue $queue,
         protected FailedJobProviderInterface $failer,
         /** @var list<string> */
         protected array $queues
     ) {
+        $this->driver = $this->unwrap($queue);
+    }
+
+    /**
+     * Resolve the concrete driver behind core's queue decorator.
+     *
+     * Core wraps whatever is bound to `flarum.queue.connection` — including our
+     * Redis queue — in a RoutingQueue so pushes can be routed to a named queue.
+     * The wrapper is not a RedisQueue, so the size lookups below have to run
+     * against the driver it wraps or every count reads as zero. `class_exists`
+     * keeps this working on cores from before the wrapper existed.
+     */
+    protected function unwrap(Queue $queue): Queue
+    {
+        while (class_exists(RoutingQueue::class) && $queue instanceof RoutingQueue) {
+            $driver = $queue->getDriver();
+
+            if ($driver === $queue) {
+                break;
+            }
+
+            $queue = $driver;
+        }
+
+        return $queue;
     }
 
     public function totals(): array
@@ -84,11 +120,11 @@ class RedisQueueStatsProvider implements QueueStatsProvider
      */
     protected function pendingSize(string $queue): int
     {
-        if (!$this->queue instanceof RedisQueue) {
+        if (!$this->driver instanceof RedisQueue) {
             return 0;
         }
 
-        return (int) $this->queue->pendingSize($queue) + (int) $this->queue->delayedSize($queue);
+        return (int) $this->driver->pendingSize($queue) + (int) $this->driver->delayedSize($queue);
     }
 
     /**
@@ -96,8 +132,8 @@ class RedisQueueStatsProvider implements QueueStatsProvider
      */
     protected function reservedSize(string $queue): int
     {
-        return $this->queue instanceof RedisQueue
-            ? (int) $this->queue->reservedSize($queue)
+        return $this->driver instanceof RedisQueue
+            ? (int) $this->driver->reservedSize($queue)
             : 0;
     }
 }

--- a/tests/integration/RedisQueueStatsProviderTest.php
+++ b/tests/integration/RedisQueueStatsProviderTest.php
@@ -14,6 +14,7 @@
 namespace FoF\Redis\Tests\integration;
 
 use Flarum\Queue\QueueStatsProvider;
+use Flarum\Queue\RoutingQueue;
 use Flarum\Testing\integration\TestCase;
 use FoF\Redis\Queue\RedisQueueStatsProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -80,6 +81,23 @@ class RedisQueueStatsProviderTest extends TestCase
         $totals = $this->stats()->totals();
         $this->assertSame(2, $totals['pending']);
         $this->assertSame(2, $this->stats()->queues()['default']['pending']);
+    }
+
+    #[Test]
+    public function pending_is_counted_through_cores_queue_decorator()
+    {
+        // Since 2.0.0-rc.6 core decorates `flarum.queue.connection` with a
+        // RoutingQueue so pushes can be routed onto a named queue. That wrapper
+        // is not an Illuminate RedisQueue, so a provider that type-checks the
+        // injected connection directly reads every count as zero while jobs sit
+        // in Redis — an idle-looking dashboard on a backed-up queue. Assert the
+        // wrapper is really in play, then that counts still come through it.
+        $queue = $this->app()->getContainer()->make('flarum.queue.connection');
+        $this->assertInstanceOf(RoutingQueue::class, $queue, 'core is expected to wrap the queue connection');
+
+        $queue->pushRaw(json_encode(['uuid' => 'w1', 'displayName' => 'X']), 'default');
+
+        $this->assertSame(1, $this->stats()->totals()['pending']);
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

CI went red on `2.x` at a4a3f61 (the `^2.0.0-rc.6` bump) with 3 failures in `RedisQueueStatsProviderTest`, on every database and under both `phpredis` and `predis`:

```
1) totals_pending_reflects_jobs_pushed_onto_redis   Failed asserting that 0 is identical to 2.
2) delayed_jobs_are_counted_as_pending             Failed asserting that 0 is identical to 3.
3) totals_sum_pending_across_named_queues          Failed asserting that 0 is identical to 3.
```

## Cause

Not a test-only problem — a real regression in the admin queue dashboard.

flarum/core#4853 (new in rc.6) decorates `flarum.queue.connection` with `Flarum\Queue\RoutingQueue`, so jobs are routed onto their registered queue at push time. `flarum.queue.connection` now resolves to the wrapper rather than to `FoF\Redis\Overrides\RedisQueue`.

`RedisQueueStatsProvider` type-checks the injected connection with `instanceof Illuminate\Queue\RedisQueue`. The wrapper isn't one, so both guards fell through to `return 0` and every pending/reserved count read as zero — **the dashboard reports an idle queue while jobs pile up in Redis.** The `failed` count was unaffected (read via the failer), which is why only the pending assertions failed.

The data was always there — `RoutingQueue` forwards `pendingSize`/`delayedSize`/`reservedSize` to the driver. Only our guard was wrong.

## Fix

Unwrap to the concrete driver in the constructor, exactly as core does for itself (`QueueServiceProvider::driverFor()`, `ApplicationInfoProvider`) via `getDriver()`. `RoutingQueue`'s own docblock anticipates this — it notes it wraps replacements "from FoF Redis / Horizon" and exposes `getDriver()` for callers needing the concrete instance.

Guarded with `class_exists` so cores from before the wrapper are unaffected, and loop-with-identity-check so nested/future decoration can't spin.

Also corrects a stale docblock: fof/redis *does* register its own failer (`RedisFailedJobProvider`), so failed jobs live in Redis, not `queue_failed_jobs`.

## Testing

- Added `pending_is_counted_through_cores_queue_decorator`, which asserts the wrapper is actually in play before asserting counts survive it — so this can't silently regress again.
- Verified the new test fails on the pre-fix code and passes after.
- Full suite green locally: **12 unit + 58 integration**, PHPStan clean.

> Heads-up: `composer.lock` is gitignored here, so local runs can go stale against a cached `vendor/`. My first full-suite run reported a false pass from the PHPUnit result cache; clearing `tests/.phpunit.cache` reproduced CI exactly.