### PR TITLE
Name the queue connection

### DIFF
--- a/src/Provides/Queue.php
+++ b/src/Provides/Queue.php
@@ -56,6 +56,13 @@ class Queue extends Provider
             );
             $queue->setContainer($container);
 
+            // Name the connection. Core names its own driver but not one we
+            // replace here, and a null name flows into the pause/resume
+            // bookkeeping and the WorkerIdle event — both of which expect a
+            // string — crashing `queue:pause`. Use core's default connection
+            // name so pause keys and the dashboard read consistently.
+            $queue->setConnectionName('flarum');
+
             return $queue;
         });
 

--- a/tests/integration/BindingsTest.php
+++ b/tests/integration/BindingsTest.php
@@ -62,6 +62,28 @@ class BindingsTest extends TestCase
         }
     }
 
+    /**
+     * The queue connection fof/redis binds must carry a name. Core names its
+     * own driver but not one an extension replaces, and a null name flows into
+     * the pause/resume bookkeeping and the WorkerIdle event — both of which
+     * expect a string — crashing `queue:pause`. Naming it here (as Horizon
+     * does) keeps the connection valid regardless of the core version.
+     */
+    #[Test]
+    public function the_queue_connection_is_named()
+    {
+        $this->flushTestDatabases();
+        $this->registerRedis();
+
+        $queue = $this->app()->getContainer()->make('flarum.queue.connection');
+
+        // Core may wrap the driver (RoutingQueue) and delegate the name down to
+        // it; assert on the driver fof/redis actually bound.
+        $driver = method_exists($queue, 'getDriver') ? $queue->getDriver() : $queue;
+
+        $this->assertSame('flarum', $driver->getConnectionName());
+    }
+
     #[Test]
     public function disable_prevents_a_service_binding_from_being_overridden()
     {


### PR DESCRIPTION
Fixes flarum/framework#4974.

The queue connection bound here carries no name. Core names its own driver, but not one an extension replaces — and that null name flows into core's pause/resume bookkeeping and the `WorkerIdle` event, both of which expect a string. So `php flarum queue:pause` crashed with a `TypeError` (exit 255) and, because it wrote the pause key before it crashed, left the queue silently paused with the dashboard unable to see it. `queue:resume --all` couldn't recover it either.

This names the connection when binding it — the same thing fof/horizon already does — using core's default connection name (`flarum`) so the pause keys and the dashboard read consistently.

It stands on its own against a released core (rc.6): `setConnectionName()` has been on Illuminate's base `Queue` for many versions, and naming the driver before core wraps it means `getConnectionName()` never returns null regardless of the core version. A companion core change (flarum/framework#4977) also names any unnamed connection at the wrap, so a future careless binding can't reintroduce this — but this fix does not depend on it.

### Testing

Reproduced on a fof/redis (no Horizon) install: `php flarum queue:pause` fatalled with exactly the reported trace, and with this branch pauses and resumes cleanly with the connection named `flarum`.

Added an integration test asserting the bound queue connection is named. The full suite is green (59 integration, 12 unit).
