### PR TITLE
[1.x] fix: make the epoch apply non-destructive to in-flight requests

### DIFF
--- a/DISTRIBUTED_CACHE.md
+++ b/DISTRIBUTED_CACHE.md
@@ -36,10 +36,17 @@ This causes missing translations (raw `core.*` keys), stale assets, and other ca
 
 ### What Gets Invalidated
 
-- `storage/formatter/*` - TextFormatter cache
-- `storage/locale/*` - Symfony translation catalogues
-- `storage/views/*` - Blade view cache
-- In-memory Symfony translator catalogues
+An apply is deliberately **non-destructive to anything a concurrent request may be using**. It forgets cache entries rather than deleting the files they reference:
+
+- the file cache (`storage/cache`), including the serialized TextFormatter entry
+- `storage/locale/*` — the compiled Symfony catalogues, plus their OPcache entries. These are the only files an apply deletes: their names are not content-derived, so nothing else would detect staleness
+- the shared settings cache (`flarum:settings`) and the resolved settings repository instance
+
+Deliberately **not** touched:
+
+- `storage/formatter/*` — the generated renderer classes. Their names are content hashes, so a rebuilt formatter simply writes new files. Deleting them mid-traffic breaks requests that are unserializing the cached formatter (incomplete object → `\Error` → 500). Core's own `Formatter::flush()` behaves the same way; `cache:clear` sweeps the orphans
+- `storage/views/*` — Blade recompiles by source mtime, and toggles or settings saves never change template sources
+- the shared compiled frontend assets and `rev-manifest.json` — core flushes those itself, once, on the pod handling the admin action
 
 ## Architecture
 
@@ -158,11 +165,11 @@ Pub/sub alone is not safe here: delivery is asynchronous, so a request landing o
 **Safe now because:**
 1. The epoch is written to Redis before the message is published
 2. Each pod checks the epoch synchronously before serving a request and clears its local caches first when behind — a rebuild can no longer start from stale local state
-3. Applying an epoch also re-flushes the compiled assets, so anything poisoned inside the tiny remaining in-flight window is erased as pods catch up
+3. The shared compiled assets and their revision manifest are flushed **only by core, once, on the pod handling the admin action**. This extension never touches them: an apply on every pod meant several concurrent writers on `rev-manifest.json`, whose updates are non-atomic read-modify-writes — interleavings lose updates and leave a revision pointing at stale content, which browsers and CDNs then cache until the next admin action
 4. Applying an epoch also drops the shared settings cache, so a pre-change snapshot re-stored by a racing refill lives milliseconds, not the full TTL
 5. Each pod applies independently and idempotently; concurrent workers on one pod are serialized by an atomic claim, and the applied epoch is recorded per pod (and per SAPI) so nothing is cleared twice
 
-**Residual window:** a request already past the epoch check when the invalidation lands can theoretically still write a stale asset after the last pod catches up. This is a tens-of-milliseconds sliver, and any later invalidation event heals it.
+**Residual window:** after core flushes the compiled assets on a toggle, the next request to render a page rebuilds them. If that request booted just before the toggle, it can bake the pre-change state into the shared asset, which then persists until the next admin action. This is core's own lazy-rebuild behaviour on 1.x (Flarum 2.x defers the rebuild to a freshly-booted request for exactly this reason); clicking *Clear Cache* once after a toggle rebuilds from a settled state.
 
 ## Future Improvements
 

--- a/DISTRIBUTED_CACHE.md
+++ b/DISTRIBUTED_CACHE.md
@@ -15,6 +15,8 @@ When cache-affecting admin actions run — clearing cache via admin panel or `ph
 
 This causes missing translations (raw `core.*` keys), stale assets, and other cache-related issues. Extension toggles and settings saves are especially insidious: Flarum core reacts to them with pod-local invalidation only and never dispatches `ClearingCache`, so without propagation the other pods stay stale until the next explicit cache clear.
 
+> **Not covered by propagation:** raw *English* core keys (`=> core.…`) appearing right after a catalogue rebuild are a separate Flarum core bug on 1.x — the hardcoded English fallback catalogue skips reference resolution when it is loaded implicitly (flarum/framework#5024; fixed in 2.x by #5023). Propagation cannot fix it, and because every pod now rebuilds its catalogues after an admin action, the bug can surface on any pod rather than only the acting one. Until core is patched, warm the English catalogue early in the request (`resolve('translator')->getCatalogue('en')`) from a site extender.
+
 ### The Solution
 
 **Automatic propagation using Redis Pub/Sub:**
@@ -36,17 +38,17 @@ This causes missing translations (raw `core.*` keys), stale assets, and other ca
 
 ### What Gets Invalidated
 
-An apply is deliberately **non-destructive to anything a concurrent request may be using**. It forgets cache entries rather than deleting the files they reference:
+An apply forgets cache entries rather than deleting the files they reference, with one exception (the locale catalogues):
 
-- the file cache (`storage/cache`), including the serialized TextFormatter entry
-- `storage/locale/*` — the compiled Symfony catalogues, plus their OPcache entries. These are the only files an apply deletes: their names are not content-derived, so nothing else would detect staleness
+- the file cache (`storage/cache`) — on 1.x its only core tenant is the serialized TextFormatter entry; core's own `Formatter::flush()` forgets just that key
+- `storage/locale/*` — the compiled Symfony catalogues. These are the only files an apply deletes: their names are not content-derived, so nothing else would detect staleness. The deletion has the same microsecond window (`is_file()` → `include`) that core's own `Extend\Locales` has on the acting pod. Their OPcache entries are invalidated too, as belt-and-braces — Symfony re-invalidates a catalogue when it rewrites it, and from the CLI subscriber the call is a no-op
 - the shared settings cache (`flarum:settings`) and the resolved settings repository instance
 
 Deliberately **not** touched:
 
-- `storage/formatter/*` — the generated renderer classes. Their names are content hashes, so a rebuilt formatter simply writes new files. Deleting them mid-traffic breaks requests that are unserializing the cached formatter (incomplete object → `\Error` → 500). Core's own `Formatter::flush()` behaves the same way; `cache:clear` sweeps the orphans
-- `storage/views/*` — Blade recompiles by source mtime, and toggles or settings saves never change template sources
-- the shared compiled frontend assets and `rev-manifest.json` — core flushes those itself, once, on the pod handling the admin action
+- `storage/formatter/*` — the generated renderer classes. This matches core's own runtime refresh (`Formatter::flush()` and the Formatter extender only forget the cache entry; `cache:clear` sweeps the files). The renderer class is autoloaded from its file *during* `unserialize()`; deleting it while another request is unserializing the cached formatter (a microsecond window) leaves that request with an incomplete object, and a method call on it throws `\Error`, which core's render guard does not catch. Residual, stated plainly: the class name is a hash of the generated code, so a rebuild after a config-neutral toggle rewrites the *same* file in place, non-atomically, and every concurrent request that misses the cache rebuilds it (on a `storage/` volume shared between pods, from every pod) — OPcache normally serves the cached copy across that window
+- `storage/views/*` — core deletes these on the acting pod when an extension that registers views is toggled, but other pods have nothing to fix: compiled views are keyed by the resolved source path and expire by source mtime, so they can only be stale if a template *source* changed, which toggles and settings saves never do
+- the shared compiled frontend assets and `rev-manifest.json` — core flushes those itself, on the pod handling the admin action (a single actor, though each flush is a dozen or so sequential writes of the manifest)
 
 ## Architecture
 
@@ -64,7 +66,9 @@ Deliberately **not** touched:
 
 Pub/Sub itself has near-zero per-request overhead. The epoch backstop adds one Redis `GET` per request by default (sub-millisecond; this extension already performs a Redis GET per request for the settings cache). Set `check_interval` to throttle the check per pod — the throttle uses APCu when available; without APCu the check runs on every request regardless.
 
-The epoch record is written to `<flarum root>/cache-epoch-<hostname>-<sapi>` — the base path must be writable by the web user. If it is not, the backstop disables itself and logs a warning (it never loops). The hostname suffix keeps records per pod even when the install root is a shared volume; the SAPI suffix lets php-fpm perform its own apply (a CLI subscriber cannot reset php-fpm's OPcache).
+The epoch record is written to `<flarum root>/cache-epoch-<hostname>-<sapi>` — the base path must be writable by the web user. If it is not, the backstop disables itself and logs a warning (it never loops). The hostname suffix keeps records per pod even when the install root is a shared volume; the SAPI suffix lets php-fpm perform its own apply (OPcache is per process pool, so a CLI subscriber's invalidation does not reach php-fpm's). Now that the apply no longer resets OPcache globally, php-fpm's second apply buys little; collapsing the two is a possible follow-up.
+
+An apply itself is not free. It drops the serialized formatter, so the next post-rendering requests on that pod rebuild it (concurrently — there is no lock), and it deletes the compiled catalogues, so the next requests recompile them. Every settings save triggers a full apply on every pod, although core itself reacts to a non-theme save with nothing pod-local; narrowing the `Saved` apply to the settings-cache forget it actually needs is a planned follow-up.
 
 ## Configuration
 
@@ -165,11 +169,11 @@ Pub/sub alone is not safe here: delivery is asynchronous, so a request landing o
 **Safe now because:**
 1. The epoch is written to Redis before the message is published
 2. Each pod checks the epoch synchronously before serving a request and clears its local caches first when behind — a rebuild can no longer start from stale local state
-3. The shared compiled assets and their revision manifest are flushed **only by core, once, on the pod handling the admin action**. This extension never touches them: an apply on every pod meant several concurrent writers on `rev-manifest.json`, whose updates are non-atomic read-modify-writes — interleavings lose updates and leave a revision pointing at stale content, which browsers and CDNs then cache until the next admin action
+3. The shared compiled assets and their revision manifest are flushed **only by core, on the pod handling the admin action** — one actor, though each flush is a dozen or so sequential read-modify-writes of the manifest. This extension never touches them: an apply on every pod meant several more concurrent writers on `rev-manifest.json`, whose updates are non-atomic read-modify-writes — interleavings lose updates and leave a revision pointing at stale content, which browsers and CDNs then cache until the next admin action. This *reduces* the writer count (core's flush plus each pod's first rebuild, instead of that plus two applies per pod); the remaining race between core's flush and the first rebuilds is core's own and is not eliminated here
 4. Applying an epoch also drops the shared settings cache, so a pre-change snapshot re-stored by a racing refill lives milliseconds, not the full TTL
 5. Each pod applies independently and idempotently; concurrent workers on one pod are serialized by an atomic claim, and the applied epoch is recorded per pod (and per SAPI) so nothing is cleared twice
 
-**Residual window:** after core flushes the compiled assets on a toggle, the next request to render a page rebuilds them. If that request booted just before the toggle, it can bake the pre-change state into the shared asset, which then persists until the next admin action. This is core's own lazy-rebuild behaviour on 1.x (Flarum 2.x defers the rebuild to a freshly-booted request for exactly this reason); clicking *Clear Cache* once after a toggle rebuilds from a settled state.
+**Residual window:** after core flushes the compiled assets on a toggle, the next request to render a page rebuilds them. If that request booted before the change was visible to it — just before the toggle, or while a racing refill's pre-change settings snapshot was still in Redis — it can bake the pre-change state into the shared asset, which then persists until the next admin action. The lazy rebuild is core's own 1.x behaviour (Flarum 2.x defers it to a freshly-booted request for exactly this reason); the pre-change settings snapshot is this extension's Redis settings layer, which is why the apply re-forgets it. Clicking *Clear Cache* once after a toggle rebuilds from a settled state. Making the manifest writes themselves atomic (a Redis-backed `VersionerInterface`, which core's `RevisionCompiler` accepts by injection) would remove the lost-update half of this; it is a candidate follow-up.
 
 ## Future Improvements
 

--- a/README.md
+++ b/README.md
@@ -291,11 +291,11 @@ composer update fof/redis
 #### Why are there still files in storage/cache?
 
 Some code still relies on physical files being present. This includes:
-- **Formatter cache** (`storage/formatter/*`) - TextFormatter configuration
+- **Formatter cache** (`storage/formatter/*`) - TextFormatter's generated renderer classes
 - **Locale cache** (`storage/locale/*`) - Compiled Symfony translation catalogues
 - **View cache** (`storage/views/*`) - Compiled Blade templates
 
-These file caches can be synchronized across multiple instances using Redis Pub/Sub. See [DISTRIBUTED_CACHE.md](DISTRIBUTED_CACHE.md) for details.
+When running several instances, a cache invalidation on one instance is propagated to the others (Redis Pub/Sub plus a per-request epoch check). A propagated invalidation forgets cache entries and deletes only the compiled locale catalogues; the formatter and view files are content- and mtime-keyed and are left in place. See [DISTRIBUTED_CACHE.md](DISTRIBUTED_CACHE.md) for details.
 
 #### Running multiple Flarum instances (horizontal scaling)?
 

--- a/src/Cache/LocalCacheInvalidator.php
+++ b/src/Cache/LocalCacheInvalidator.php
@@ -14,7 +14,6 @@
 namespace FoF\Redis\Cache;
 
 use Flarum\Foundation\Paths;
-use Flarum\Frontend\RecompileFrontendAssets;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Cache\Repository;
@@ -22,17 +21,19 @@ use Illuminate\Contracts\Container\Container;
 use Psr\Log\LoggerInterface;
 
 /**
- * Applies a cache invalidation on this pod: clears the pod-local file caches,
- * drops the shared settings cache, and flushes the compiled frontend assets so
- * the next rebuild happens from fresh state. (Flushing is safe here on 1.x:
- * FileVersioner reads the revision manifest fresh from disk on every call, so
- * a long-running subscriber cannot rewrite it from a stale snapshot.).
+ * Applies a cache invalidation on this pod.
+ *
+ * The apply is deliberately NON-DESTRUCTIVE to anything a concurrent request
+ * may be using: it forgets cache entries (pointers) rather than deleting the
+ * files those entries reference, and never touches the shared compiled assets.
+ * The only files it removes are the compiled locale catalogues, whose names are
+ * not content-derived — deletion is the only way to force their rebuild.
  *
  * The applied epoch is recorded per pod AND per SAPI: the CLI subscriber and
  * php-fpm each keep their own record, because some work is only effective in
- * the SAPI that performs it (opcache_reset() in a CLI process cannot touch
- * php-fpm's OPcache). The invalidation is idempotent, so applying it once per
- * SAPI is safe and cheap.
+ * the SAPI that performs it (OPcache invalidation from the CLI subscriber cannot
+ * touch php-fpm's OPcache). The invalidation is idempotent, so applying it once
+ * per SAPI is safe and cheap.
  */
 class LocalCacheInvalidator
 {
@@ -60,22 +61,26 @@ class LocalCacheInvalidator
 
     public function invalidate(): void
     {
-        // CRITICAL: Flush FileStore cache FIRST before deleting files
-        // This prevents __PHP_Incomplete_Class__ errors with TextFormatter
-        // The FileStore contains serialized formatter objects that reference
-        // class files in storage/formatter/. We must clear the serialized cache
-        // before deleting the class files, otherwise unserialization fails.
+        // Forget the file-cache entries (among them `flarum.formatter`, the
+        // serialized TextFormatter). The formatter's generated renderer CLASS
+        // FILES in storage/formatter/ are deliberately left in place: their
+        // names are content hashes, so a rebuilt formatter writes new files and
+        // the superseded ones are inert. Deleting them mid-traffic breaks
+        // requests that are unserializing the cached formatter — the class file
+        // vanishes, the object comes back incomplete, and calling a method on it
+        // throws \Error (not \Exception, so it escapes core's render guard and
+        // becomes a 500). Core's own runtime refresh, Formatter::flush(), also
+        // only forgets the cache entry; `cache:clear` sweeps the orphans.
         (new Repository($this->container->make('cache.filestore')))->flush();
 
-        // Clear file caches (suppress warnings if files don't exist).
-        // storage/locale is handled by LocaleManager::clearCache() below.
-        @array_map('unlink', glob($this->paths->storage.'/formatter/*') ?: []);
-        @array_map('unlink', glob($this->paths->storage.'/views/*') ?: []);
+        // Compiled Blade views are left alone for the same reason: Blade
+        // recompiles by source mtime, and toggles or settings saves never change
+        // template sources (deployments do, and those run cache:clear).
 
-        // Delete the compiled Symfony catalogue files. The catalogue cache file
-        // names are not keyed by their source resources, so this is what forces
-        // a rebuild from the (always-correct) YAML sources.
-        $this->locales->clearCache();
+        // The compiled locale catalogues are the exception: their filenames are
+        // not derived from their contents, so nothing detects staleness and
+        // deletion is the only way to force a rebuild from the YAML sources.
+        $this->clearLocaleCatalogues();
 
         // Drop the shared settings cache as well: a concurrent refill that read the DB
         // just before the invalidating write can re-store a pre-change snapshot AFTER
@@ -97,17 +102,35 @@ class LocalCacheInvalidator
             }
         }
 
-        // Flush the compiled frontend assets too. They may have been rebuilt by a pod
-        // whose locale catalogue was still stale (the assets live on shared storage but
-        // are compiled from pod-local state); flushing them after clearing our local
-        // caches means the next rebuild happens from fresh state.
-        $this->flushCompiledAssets();
+        // NOTE: the shared compiled frontend assets are deliberately NOT touched.
+        // Core flushes them itself, once, on the pod that handles the admin
+        // action. Flushing again from every pod's apply meant up to 2N actors
+        // per toggle rewriting rev-manifest.json, whose updates are non-atomic
+        // read-modify-writes: interleavings lose updates, leaving a revision
+        // pointing at stale content that browsers and CDNs then cache until the
+        // next admin action.
+    }
 
-        // Clear OPcache if available. Only effective for the SAPI we run in (a CLI
-        // subscriber cannot reset php-fpm's OPcache) — which is why the applied
-        // epoch is recorded per SAPI: php-fpm performs its own apply.
-        if (function_exists('opcache_reset')) {
-            opcache_reset();
+    /**
+     * Delete the compiled locale catalogues and drop their OPcache entries.
+     *
+     * Targeted invalidation rather than opcache_reset(): a global reset
+     * restarts the whole php-fpm pool mid-traffic (recompile storm, and
+     * lazily-autoloaded classes can fail during the swap), which is far more
+     * disruptive than the staleness it guards against.
+     */
+    protected function clearLocaleCatalogues(): void
+    {
+        $files = glob($this->paths->storage.'/locale/*.php') ?: [];
+
+        $this->locales->clearCache();
+
+        if (!function_exists('opcache_invalidate')) {
+            return;
+        }
+
+        foreach ($files as $file) {
+            @opcache_invalidate($file, true);
         }
     }
 
@@ -148,8 +171,8 @@ class LocalCacheInvalidator
     /**
      * Atomically claim the right to apply an epoch, so concurrent php-fpm
      * workers crossing the same request boundary don't all run the full
-     * invalidation (N concurrent opcache resets). fopen('x') is the exclusive
-     * primitive; a stale claim from a crashed worker is broken after 60s.
+     * invalidation at once. fopen('x') is the exclusive primitive; a stale
+     * claim from a crashed worker is broken after 60s.
      */
     public function claimEpoch(int $version): bool
     {
@@ -215,20 +238,6 @@ class LocalCacheInvalidator
         $host = gethostname() ?: 'pod';
 
         return preg_replace('/[^A-Za-z0-9_.-]/', '-', $host).'-'.PHP_SAPI;
-    }
-
-    protected function flushCompiledAssets(): void
-    {
-        foreach (['forum', 'admin'] as $frontend) {
-            try {
-                (new RecompileFrontendAssets(
-                    $this->container->make("flarum.assets.$frontend"),
-                    $this->locales
-                ))->flush();
-            } catch (\Throwable $e) {
-                // A frontend may not be bound in some contexts; skip it.
-            }
-        }
     }
 
     /**

--- a/src/Cache/LocalCacheInvalidator.php
+++ b/src/Cache/LocalCacheInvalidator.php
@@ -23,17 +23,20 @@ use Psr\Log\LoggerInterface;
 /**
  * Applies a cache invalidation on this pod.
  *
- * The apply is deliberately NON-DESTRUCTIVE to anything a concurrent request
- * may be using: it forgets cache entries (pointers) rather than deleting the
- * files those entries reference, and never touches the shared compiled assets.
- * The only files it removes are the compiled locale catalogues, whose names are
- * not content-derived — deletion is the only way to force their rebuild.
+ * The apply forgets cache entries rather than deleting the files those entries
+ * reference, and never touches the shared compiled assets. The only files it
+ * removes are the compiled locale catalogues, whose names are not
+ * content-derived — deletion is the only way to force their rebuild. That
+ * deletion has the same microsecond window (is_file() → include) that core's
+ * own Extend\Locales::onEnable/onDisable has on the acting pod.
  *
  * The applied epoch is recorded per pod AND per SAPI: the CLI subscriber and
- * php-fpm each keep their own record, because some work is only effective in
- * the SAPI that performs it (OPcache invalidation from the CLI subscriber cannot
- * touch php-fpm's OPcache). The invalidation is idempotent, so applying it once
- * per SAPI is safe and cheap.
+ * php-fpm each keep their own record, so php-fpm performs its own apply even
+ * when the subscriber already did (OPcache is per process pool: entries
+ * dropped by the CLI process do not affect php-fpm's). The invalidation is
+ * idempotent, so applying it once per SAPI is safe. Now that the apply no
+ * longer resets OPcache globally, the second apply buys little — collapsing
+ * the two is a possible follow-up.
  */
 class LocalCacheInvalidator
 {
@@ -61,21 +64,31 @@ class LocalCacheInvalidator
 
     public function invalidate(): void
     {
-        // Forget the file-cache entries (among them `flarum.formatter`, the
-        // serialized TextFormatter). The formatter's generated renderer CLASS
-        // FILES in storage/formatter/ are deliberately left in place: their
-        // names are content hashes, so a rebuilt formatter writes new files and
-        // the superseded ones are inert. Deleting them mid-traffic breaks
-        // requests that are unserializing the cached formatter — the class file
-        // vanishes, the object comes back incomplete, and calling a method on it
-        // throws \Error (not \Exception, so it escapes core's render guard and
-        // becomes a 500). Core's own runtime refresh, Formatter::flush(), also
-        // only forgets the cache entry; `cache:clear` sweeps the orphans.
+        // Flush the file cache. On 1.x its only core tenant is `flarum.formatter`,
+        // the serialized TextFormatter (core's own Formatter::flush() forgets
+        // just that key). The formatter's generated renderer CLASS FILES in
+        // storage/formatter/ are deliberately left in place, matching core's
+        // runtime refresh: Formatter::flush() and the Formatter extender's
+        // onEnable/onDisable only forget the cache entry, and `cache:clear` is
+        // what sweeps the files. The renderer class is autoloaded from that
+        // file DURING unserialize(); deleting it while another request is
+        // unserializing the cached formatter — a microsecond window — leaves
+        // that request with an incomplete object, and a method call on it
+        // throws \Error, which core's render guard (catch Exception) does not
+        // catch. Residual: the class name is a hash of the generated code, so
+        // a rebuild after a config-neutral toggle rewrites the SAME file in
+        // place, non-atomically, and every concurrent request that misses the
+        // cache rebuilds it — OPcache normally serves the cached copy across
+        // that window.
         (new Repository($this->container->make('cache.filestore')))->flush();
 
-        // Compiled Blade views are left alone for the same reason: Blade
-        // recompiles by source mtime, and toggles or settings saves never change
-        // template sources (deployments do, and those run cache:clear).
+        // Compiled Blade views are left alone too. Core deletes them on the
+        // acting pod when an extension that registers views is toggled
+        // (Extend\View), but on other pods there is nothing to fix: compiled
+        // files are keyed by the resolved source path and expire by source
+        // mtime, so they can only be stale if a template SOURCE changed —
+        // which toggles and settings saves never do (deployments do, and
+        // those run cache:clear).
 
         // The compiled locale catalogues are the exception: their filenames are
         // not derived from their contents, so nothing detects staleness and
@@ -112,12 +125,15 @@ class LocalCacheInvalidator
     }
 
     /**
-     * Delete the compiled locale catalogues and drop their OPcache entries.
+     * Delete the compiled locale catalogues and invalidate their OPcache
+     * entries in this SAPI.
      *
-     * Targeted invalidation rather than opcache_reset(): a global reset
-     * restarts the whole php-fpm pool mid-traffic (recompile storm, and
-     * lazily-autoloaded classes can fail during the swap), which is far more
-     * disruptive than the staleness it guards against.
+     * The invalidation is belt-and-braces: Symfony re-invalidates a catalogue
+     * when it rewrites it, and from the CLI subscriber the call is a no-op
+     * (opcache.enable_cli is off by default). It replaces the previous global
+     * opcache_reset(), which forced the whole php-fpm pool to recompile
+     * everything mid-traffic — far more disruptive than the staleness it
+     * guarded against.
      */
     protected function clearLocaleCatalogues(): void
     {
@@ -220,8 +236,8 @@ class LocalCacheInvalidator
      * The epoch record lives in the base path (like the subscriber lock files),
      * suffixed by hostname AND SAPI: the hostname keeps records per pod even
      * when the install root is a volume shared between pods, and the SAPI
-     * keeps the CLI subscriber's apply from suppressing php-fpm's (whose
-     * opcache_reset is the only one that matters).
+     * keeps the CLI subscriber's apply from suppressing php-fpm's (OPcache is
+     * per process pool, so only php-fpm's own apply reaches its OPcache).
      */
     public function epochFilePath(): string
     {

--- a/tests/integration/PubSubCacheInvalidationTest.php
+++ b/tests/integration/PubSubCacheInvalidationTest.php
@@ -240,9 +240,30 @@ class PubSubCacheInvalidationTest extends TestCase
 
         /** @var Paths $paths */
         $paths = $container->make(Paths::class);
+
+        // Only the locale catalogues may be deleted by an apply.
         @mkdir($paths->storage.'/locale', 0777, true);
-        $sentinel = $paths->storage.'/locale/sentinel.tmp';
-        file_put_contents($sentinel, 'stale catalogue');
+        $localeSentinel = $paths->storage.'/locale/sentinel.tmp';
+        file_put_contents($localeSentinel, 'stale catalogue');
+
+        // Everything a concurrent request may still be using must survive:
+        // the formatter's renderer class files (deleting them mid-request
+        // yields an incomplete object and a 500), the compiled Blade views,
+        // and the shared compiled assets with their revision manifest.
+        @mkdir($paths->storage.'/formatter', 0777, true);
+        $formatterSentinel = $paths->storage.'/formatter/Renderer_sentinel.php';
+        file_put_contents($formatterSentinel, '<?php class Renderer_sentinel {}');
+
+        @mkdir($paths->storage.'/views', 0777, true);
+        $viewSentinel = $paths->storage.'/views/sentinel.php';
+        file_put_contents($viewSentinel, '<?php /* compiled view */');
+
+        @mkdir($paths->public.'/assets', 0777, true);
+        $manifest = $paths->public.'/assets/rev-manifest.json';
+        $manifestBefore = file_exists($manifest) ? file_get_contents($manifest) : '{"forum.js":"sentinel"}';
+        file_put_contents($manifest, $manifestBefore);
+        $assetSentinel = $paths->public.'/assets/forum-sentinel.js';
+        file_put_contents($assetSentinel, '/* compiled asset */');
 
         /** @var LocalCacheInvalidator $invalidator */
         $invalidator = $container->make(LocalCacheInvalidator::class);
@@ -259,18 +280,26 @@ class PubSubCacheInvalidationTest extends TestCase
         $response = $this->runMiddleware($invalidator);
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertFileDoesNotExist($sentinel, 'A pod behind the epoch should clear its local caches before serving');
         $this->assertSame($version, $invalidator->appliedVersion());
+        $this->assertFileDoesNotExist($localeSentinel, 'A pod behind the epoch should clear its locale catalogues before serving');
 
-        // The apply drops the poisoned snapshot; a settings read later in the
-        // apply (e.g. while flushing compiled assets) may legitimately re-warm
-        // the cache FROM THE DATABASE, so the guarantee is "the stale snapshot
-        // is gone", not "the cache is empty".
+        $this->assertFileExists($formatterSentinel, 'An apply must not delete formatter class files a concurrent request may be unserializing');
+        $this->assertFileExists($viewSentinel, 'An apply must not delete compiled Blade views');
+        $this->assertFileExists($assetSentinel, 'An apply must not delete the shared compiled assets');
+        $this->assertSame($manifestBefore, file_get_contents($manifest), 'An apply must not rewrite the shared revision manifest');
+
+        // The apply drops the poisoned snapshot; a later settings read may
+        // legitimately re-warm the cache FROM THE DATABASE, so the guarantee is
+        // "the stale snapshot is gone", not "the cache is empty".
         $cached = $settingsCache->get('flarum:settings');
         $this->assertTrue(
             $cached === null || (is_array($cached) && !array_key_exists('stale', $cached)),
             'Applying an epoch should drop the stale settings snapshot'
         );
+
+        @unlink($formatterSentinel);
+        @unlink($viewSentinel);
+        @unlink($assetSentinel);
     }
 
     /**

--- a/tests/integration/PubSubCacheInvalidationTest.php
+++ b/tests/integration/PubSubCacheInvalidationTest.php
@@ -24,6 +24,7 @@ use FoF\Redis\Cache\LocalCacheInvalidator;
 use FoF\Redis\Console\CacheSubscribeCommand;
 use FoF\Redis\Extend\Redis as RedisExtender;
 use FoF\Redis\Middleware\DistributedCacheInvalidation;
+use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Redis\Factory;
 use Laminas\Diactoros\Response;
@@ -54,10 +55,17 @@ class PubSubCacheInvalidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // Remove per-pod epoch records and claims so no test inherits state.
+        // Remove per-pod epoch records and claims, and the sentinel files the
+        // apply test seeds, so no test inherits state.
         try {
-            $base = $this->app()->getContainer()->make(Paths::class)->base;
-            @array_map('unlink', glob($base.'/cache-epoch-*') ?: []);
+            $paths = $this->app()->getContainer()->make(Paths::class);
+            @array_map('unlink', glob($paths->base.'/cache-epoch-*') ?: []);
+            @array_map('unlink', array_filter([
+                $paths->storage.'/formatter/Renderer_sentinel.php',
+                $paths->storage.'/views/sentinel.php',
+                $paths->public.'/assets/forum.js',
+                $paths->public.'/assets/rev-manifest.json',
+            ], 'file_exists'));
         } catch (\Exception $e) {
             // App may not have booted in this test.
         }
@@ -246,10 +254,18 @@ class PubSubCacheInvalidationTest extends TestCase
         $localeSentinel = $paths->storage.'/locale/sentinel.tmp';
         file_put_contents($localeSentinel, 'stale catalogue');
 
-        // Everything a concurrent request may still be using must survive:
-        // the formatter's renderer class files (deleting them mid-request
-        // yields an incomplete object and a 500), the compiled Blade views,
-        // and the shared compiled assets with their revision manifest.
+        // The file cache itself must be forgotten (the serialized formatter
+        // lives there under `flarum.formatter`)...
+        $fileCache = new Repository($container->make('cache.filestore'));
+        $fileCache->forever('flarum.formatter', 'stale serialized formatter');
+
+        // ...but everything a concurrent request may still be using must
+        // survive: the formatter's renderer class files (deleting them
+        // mid-request yields an incomplete object and a 500), the compiled
+        // Blade views, and the shared compiled assets with their revision
+        // manifest. The manifest is always seeded with a revision for the
+        // asset sentinel, so a re-introduced asset flush would have something
+        // to act on (`RevisionCompiler::flush()` is a no-op without one).
         @mkdir($paths->storage.'/formatter', 0777, true);
         $formatterSentinel = $paths->storage.'/formatter/Renderer_sentinel.php';
         file_put_contents($formatterSentinel, '<?php class Renderer_sentinel {}');
@@ -260,9 +276,9 @@ class PubSubCacheInvalidationTest extends TestCase
 
         @mkdir($paths->public.'/assets', 0777, true);
         $manifest = $paths->public.'/assets/rev-manifest.json';
-        $manifestBefore = file_exists($manifest) ? file_get_contents($manifest) : '{"forum.js":"sentinel"}';
+        $manifestBefore = '{"forum.js":"sentinel"}';
         file_put_contents($manifest, $manifestBefore);
-        $assetSentinel = $paths->public.'/assets/forum-sentinel.js';
+        $assetSentinel = $paths->public.'/assets/forum.js';
         file_put_contents($assetSentinel, '/* compiled asset */');
 
         /** @var LocalCacheInvalidator $invalidator */
@@ -282,6 +298,7 @@ class PubSubCacheInvalidationTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame($version, $invalidator->appliedVersion());
         $this->assertFileDoesNotExist($localeSentinel, 'A pod behind the epoch should clear its locale catalogues before serving');
+        $this->assertNull($fileCache->get('flarum.formatter'), 'An apply must forget the cached serialized formatter');
 
         $this->assertFileExists($formatterSentinel, 'An apply must not delete formatter class files a concurrent request may be unserializing');
         $this->assertFileExists($viewSentinel, 'An apply must not delete compiled Blade views');
@@ -297,9 +314,7 @@ class PubSubCacheInvalidationTest extends TestCase
             'Applying an epoch should drop the stale settings snapshot'
         );
 
-        @unlink($formatterSentinel);
-        @unlink($viewSentinel);
-        @unlink($assetSentinel);
+        // Seeded sentinels are removed in tearDown().
     }
 
     /**


### PR DESCRIPTION
Follow-up to #34, from running v1.1.7 on a 3-instance production forum.

## The problem

#34 made invalidation propagate, but the apply it introduced kept the **full-reset recipe** this extension's subscriber has used since v1.1.0 (#3) — flush the file cache, delete `storage/formatter/*`, `storage/views/*`, `storage/locale/*`, `opcache_reset()` — and changed how often it runs. Before #34 that recipe ran only on an explicit `cache:clear`, on the pods whose subscriber received the message. Since v1.1.7 it runs on **every settings save and extension toggle, on every pod, twice per pod (subscriber and php-fpm), in the request path, while visitors are mid-page**. The recipe is far more destructive than core's own runtime reaction to the same events — core's `Formatter::flush()` only forgets a cache entry, and core never touches OPcache at all.

Observed in production:

- **Sporadic 500s** on API endpoints during/after admin actions. The exception itself was not captured, so the mechanism below is the one this PR *removes*, not one it has proven: `storage/formatter/*` holds TextFormatter's generated renderer classes, autoloaded *during* `unserialize()` of the cached formatter (`Formatter::getRenderer()`). Deleting a class file while another request is unserializing — a microsecond window, but one that v1.1.7 opened twice per pod per admin action while the formatter is unserialized on every post render — leaves that request with an incomplete object, and a method call on it throws `\Error`, **not** `\Exception`, so it escapes the `catch (Exception $e)` guard in `BasicPostSerializer::getDefaultAttributes()` and becomes a 500. Production logs from the same seconds show incomplete `Renderer_<hash>` objects, but those warnings also occur on healthy parse-only requests (`getParser()` unserializes without the autoloader), so they are consistent with the hypothesis rather than proof of it.
- **Stale shared assets**: a disable not reflected on the forum, a newly enabled extension's settings page empty, and mixed revisions (`admin-de.js` advanced while `admin.js` stayed put) — the signature of lost updates on `rev-manifest.json`, whose updates are non-atomic read-modify-writes. A single toggle produced up to 2N+1 concurrent writers (core + each pod's subscriber + each pod's first request), each performing a dozen or so sequential RMWs; on a setup where assets live on S3 those span network round-trips, so interleaving is likely rather than exotic. Because a present revision is never re-examined (`RevisionCompiler::getUrl()` only commits when the revision is *missing*), a lost update persists until the next admin action, and browsers/CDNs keep the stale URL.

## The change

An apply now **forgets cache entries rather than deleting the files those entries reference** — the same thing core itself does when it reacts to these events at runtime:

| Action | Before | Now | Why |
|---|---|---|---|
| Shared compiled assets | flushed by every pod's apply | **untouched** | Core already flushes them on the acting pod. Our extra flushes only added manifest writers. |
| `storage/formatter/*` | deleted | **untouched** | Matches core's `Formatter::flush()` and the Formatter extender, which only forget the cache entry; `cache:clear` sweeps the files. Residual, stated plainly: the class name is a hash of the generated code, so a config-neutral rebuild rewrites the *same* file in place, non-atomically, and concurrent cache misses each rebuild it — OPcache normally serves the cached copy across that window. |
| `storage/views/*` | deleted | **untouched** | Compiled views are keyed by resolved source path and expire by source mtime, so another pod's can only be stale if a template *source* changed; toggles and saves never do that (deployments do, and those run `cache:clear`). Core does delete them on the acting pod for extensions with views — that's the acting pod's business. |
| OPcache | global `opcache_reset()` | `opcache_invalidate()` on the locale files we delete | A global reset forces the whole php-fpm pool to recompile everything mid-traffic — more disruptive than the staleness it guarded against. Core never resets OPcache. The targeted call is belt-and-braces (Symfony re-invalidates a catalogue when it rewrites it; from the CLI subscriber it is a no-op). |
| File cache, locale catalogues, settings cache, epoch record | unchanged | unchanged | The locale catalogues are the one cache whose filenames aren't content-derived, so deletion is the only way to force their rebuild; the window is the same one core's own `Extend\Locales` has on the acting pod. |

Net effect: **less code, fewer actions, no new machinery.**

`DISTRIBUTED_CACHE.md` and the README FAQ are updated to match: "What Gets Invalidated" lists what an apply touches and what it deliberately leaves alone, with the residuals above stated; "Performance" now states the real per-apply cost; "Race Conditions?" is explicit that the manifest race is *reduced* (fewer writers), not eliminated.

## What this does and does not fix

- **Fixed vs v1.1.7:** the 500 path and the extra manifest writers.
- **Preserved from #34:** pods B/C heal their stale extension translations and formatter config on toggle/save — which v1.1.6 never did.
- **Back to core's 1.x baseline, not zero:** lost manifest updates between core's own flush and each pod's first rebuild, and the lazy-rebuild residual below. 2.x already solves the latter (`RecompileFrontendAssets::markDirty()` / `recompileIfDirty()`); reproducing that from an extension isn't possible while core's `Enabled` listeners still call `flush()`, so this PR deliberately stops at core's baseline rather than adding an elected re-flush — the previous attempt at extra machinery traded a partial, non-deterministic heal for the manifest race above. Making the manifest writes atomic (a Redis-backed `VersionerInterface`, which `RevisionCompiler` accepts by injection) would remove the lost-update half; candidate follow-up.
- **Not fixable here:** raw *English* core keys after a catalogue rebuild are a core 1.x bug (flarum/framework#5024, open; fixed in 2.x by #5023). Correct propagation makes every pod rebuild its catalogues, so until core is patched the bug can surface on any pod — sites should warm the English catalogue early in the request from a site extender. `DISTRIBUTED_CACHE.md` says so.

**Residual window:** after core flushes the compiled assets on a toggle, the next request to render a page rebuilds them. If that request booted before the change was visible to it, it can bake the pre-change state into the shared asset, which persists until the next admin action.

## Follow-ups (not in this PR, to keep it subtractive)

1. #37 — `Saved` currently triggers the full apply on every pod, although core reacts to a non-theme save with nothing pod-local; a kind-tagged epoch could narrow it to the settings-cache forget.
2. With `opcache_reset()` gone the per-SAPI double apply buys little; collapse to one per pod.
3. #38 — Redis-backed atomic `VersionerInterface` (above).

## Tests

`middleware_applies_newer_epoch_and_clears_local_caches` pins the whole contract: after an apply, the locale catalogue sentinel is gone and `flarum.formatter` is no longer in the file cache, while sentinels in `storage/formatter/`, `storage/views/`, `public/assets/forum.js` and the contents of `rev-manifest.json` are unchanged. The manifest is always seeded with a revision for the asset sentinel, so a re-introduced asset flush has something to act on (`RevisionCompiler::flush()` is a no-op without one); seeded files are removed in `tearDown`. Red-before/green-after verified per assertion against the previous `src/`: each of the four non-destructive assertions fails independently.

Local run against MySQL 8 + Redis 7: PHPStan clean, unit 11/11, integration 12/12 (twice back-to-back).

## 2.x

A companion PR against `2.x` **is** needed. The 2.x apply (#35) already handles the shared assets correctly via core's `markDirty()` and never writes the manifest — but it still deletes `storage/formatter/*` and `storage/views/*` and still calls `opcache_reset()`, so three of the four changes here apply there too: #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
