### PR TITLE
[2.x] fix: make the epoch apply non-destructive to in-flight requests

### DIFF
--- a/DISTRIBUTED_CACHE.md
+++ b/DISTRIBUTED_CACHE.md
@@ -36,10 +36,19 @@ This causes missing translations (raw `core.*` keys), stale assets, and other ca
 
 ### What Gets Invalidated
 
-- `storage/formatter/*` - TextFormatter cache
-- `storage/locale/*` - Symfony translation catalogues
-- `storage/views/*` - Blade view cache
-- In-memory Symfony translator catalogues
+An apply forgets cache entries rather than deleting the files they reference, with one exception (the locale catalogues):
+
+- the file cache (`storage/cache`) — its core tenant is the serialized TextFormatter entry; core's own `Formatter::flush()` forgets just that key
+- `storage/locale/*` — the compiled Symfony catalogues (and the in-memory translator catalogues). These are the only files an apply deletes: their names are not content-derived, so nothing else would detect staleness. The deletion has the same microsecond window (`is_file()` → `include`) that core's own `Extend\Locales` has on the acting pod. Their OPcache entries are invalidated too, as belt-and-braces — Symfony re-invalidates a catalogue when it rewrites it, and from the CLI subscriber the call is a no-op
+- the shared settings cache (`flarum:settings`) and the resolved settings repository instance
+- every compiled asset set is marked **dirty** (core's `RecompileFrontendAssets::markDirty()`), so core rebuilds it in place early in the next freshly-booted request
+
+Deliberately **not** touched:
+
+- `storage/formatter/*` — the generated renderer classes. This matches core's own runtime refresh (`Formatter::flush()` and the Formatter extender only forget the cache entry; `cache:clear` sweeps the files). The renderer class is autoloaded from its file *during* `unserialize()`; deleting it while another request is unserializing the cached formatter (a microsecond window) leaves that request with an incomplete object, and a method call on it throws `\Error`, which core's render guard does not catch. Residual, stated plainly: the class name is a hash of the generated code, so a rebuild after a config-neutral toggle rewrites the *same* file in place, non-atomically, and every concurrent request that misses the cache rebuilds it — OPcache normally serves the cached copy across that window
+- `storage/views/*` — core deletes these on the acting pod when an extension that registers views is toggled, but other pods have nothing to fix: compiled views are keyed by the resolved source path and expire by source mtime, so they can only be stale if a template *source* changed, which toggles and settings saves never do
+- the compiled frontend assets and `rev-manifest.json` — never flushed or rewritten by this extension; marking them dirty is core's own mechanism
+- OPcache as a whole — no global `opcache_reset()`; it forced the whole php-fpm pool to recompile everything mid-traffic
 
 ## Architecture
 
@@ -57,7 +66,9 @@ This causes missing translations (raw `core.*` keys), stale assets, and other ca
 
 Pub/Sub itself has near-zero per-request overhead. The epoch backstop adds one Redis `GET` per request by default (sub-millisecond; this extension already performs a Redis GET per request for the settings cache). Set `check_interval` to throttle the check per pod — the throttle uses APCu when available; without APCu the check runs on every request regardless.
 
-The epoch record is written to `<flarum root>/cache-epoch-<hostname>-<sapi>` — the base path must be writable by the web user. If it is not, the backstop disables itself and logs a warning (it never loops). The hostname suffix keeps records per pod even when the install root is a shared volume; the SAPI suffix lets php-fpm perform its own apply (a CLI subscriber cannot reset php-fpm's OPcache).
+The epoch record is written to `<flarum root>/cache-epoch-<hostname>-<sapi>` — the base path must be writable by the web user. If it is not, the backstop disables itself and logs a warning (it never loops). The hostname suffix keeps records per pod even when the install root is a shared volume; the SAPI suffix lets php-fpm perform its own apply (OPcache is per process pool, so a CLI subscriber's invalidation does not reach php-fpm's). Now that the apply no longer resets OPcache globally, php-fpm's second apply buys little; collapsing the two is a possible follow-up.
+
+An apply itself is not free. It drops the serialized formatter, so the next post-rendering requests on that pod rebuild it (concurrently — there is no lock), and it deletes the compiled catalogues, so the next requests recompile them. Every settings save triggers a full apply on every pod, although core itself reacts to a non-theme save with nothing pod-local; narrowing the `Saved` apply to the settings-cache forget it actually needs is a planned follow-up.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ composer update fof/redis
 ### FAQ
 
 *Why are there still files in storage/cache?*
-Some code still relies on physical files being present. This includes the formatter cache and the view caches.
+Some code still relies on physical files being present. This includes the formatter cache and the view caches. A propagated invalidation (see [DISTRIBUTED_CACHE.md](DISTRIBUTED_CACHE.md)) leaves those files in place — they are content- and mtime-keyed — and deletes only the compiled locale catalogues.
 
 ### Links
 

--- a/src/Cache/LocalCacheInvalidator.php
+++ b/src/Cache/LocalCacheInvalidator.php
@@ -24,17 +24,26 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Psr\Log\LoggerInterface;
 
 /**
- * Applies a cache invalidation on this pod: clears the pod-local file caches,
- * drops the shared settings cache, and marks every compiled asset set dirty so
- * core rebuilds it in place on the next request (see
+ * Applies a cache invalidation on this pod: forgets the pod-local cache
+ * entries, drops the shared settings cache, and marks every compiled asset set
+ * dirty so core rebuilds it in place on the next request (see
  * RecompileFrontendAssets::markDirty() — nothing is deleted, so already-served
  * asset URLs keep resolving and the revision token doesn't flicker).
  *
+ * The apply forgets cache entries rather than deleting the files those entries
+ * reference. The only files it removes are the compiled locale catalogues,
+ * whose names are not content-derived — deletion is the only way to force
+ * their rebuild. That deletion has the same microsecond window (is_file() →
+ * include) that core's own Extend\Locales::onEnable/onDisable has on the
+ * acting pod.
+ *
  * The applied epoch is recorded per pod AND per SAPI: the CLI subscriber and
- * php-fpm each keep their own record, because some work is only effective in
- * the SAPI that performs it (opcache_reset() in a CLI process cannot touch
- * php-fpm's OPcache). The invalidation is idempotent, so applying it once per
- * SAPI is safe and cheap.
+ * php-fpm each keep their own record, so php-fpm performs its own apply even
+ * when the subscriber already did (OPcache is per process pool: entries
+ * dropped by the CLI process do not affect php-fpm's). The invalidation is
+ * idempotent, so applying it once per SAPI is safe. Now that the apply no
+ * longer resets OPcache globally, the second apply buys little — collapsing
+ * the two is a possible follow-up.
  */
 class LocalCacheInvalidator
 {
@@ -47,23 +56,36 @@ class LocalCacheInvalidator
 
     public function invalidate(): void
     {
-        // CRITICAL: Flush FileStore cache FIRST before deleting files
-        // This prevents __PHP_Incomplete_Class__ errors with TextFormatter
-        // The FileStore contains serialized formatter objects that reference
-        // class files in storage/formatter/. We must clear the serialized cache
-        // before deleting the class files, otherwise unserialization fails.
+        // Flush the file cache; its core tenant is `flarum.formatter`, the
+        // serialized TextFormatter (core's own Formatter::flush() forgets just
+        // that key). The formatter's generated renderer CLASS FILES in
+        // storage/formatter/ are deliberately left in place, matching core's
+        // runtime refresh: Formatter::flush() and the Formatter extender's
+        // onEnable/onDisable only forget the cache entry, and `cache:clear` is
+        // what sweeps the files. The renderer class is autoloaded from that
+        // file DURING unserialize(); deleting it while another request is
+        // unserializing the cached formatter — a microsecond window — leaves
+        // that request with an incomplete object, and a method call on it
+        // throws \Error, which core's render guard (catch Exception) does not
+        // catch. Residual: the class name is a hash of the generated code, so
+        // a rebuild after a config-neutral toggle rewrites the SAME file in
+        // place, non-atomically, and every concurrent request that misses the
+        // cache rebuilds it — OPcache normally serves the cached copy across
+        // that window.
         (new Repository($this->container->make('cache.filestore')))->flush();
 
-        // Clear file caches (suppress warnings if files don't exist).
-        // storage/locale is handled by LocaleManager::clearCache() below.
-        @array_map('unlink', glob($this->paths->storage.'/formatter/*') ?: []);
-        @array_map('unlink', glob($this->paths->storage.'/views/*') ?: []);
+        // Compiled Blade views are left alone too. Core deletes them on the
+        // acting pod when an extension that registers views is toggled
+        // (Extend\View), but on other pods there is nothing to fix: compiled
+        // files are keyed by the resolved source path and expire by source
+        // mtime, so they can only be stale if a template SOURCE changed —
+        // which toggles and settings saves never do (deployments do, and
+        // those run cache:clear).
 
-        // Delete the compiled Symfony catalogue files. In 2.x clearCache()
-        // only unlinks the cache dir — the catalogue cache file names are not
-        // keyed by their source resources, so this is what forces a rebuild
-        // from the (always-correct) YAML sources.
-        $this->locales->clearCache();
+        // The compiled locale catalogues are the exception: their filenames are
+        // not derived from their contents, so nothing detects staleness and
+        // deletion is the only way to force a rebuild from the YAML sources.
+        $this->clearLocaleCatalogues();
 
         // Drop the shared settings cache as well: a concurrent refill that read the DB
         // just before the invalidating write can re-store a pre-change snapshot AFTER
@@ -90,12 +112,31 @@ class LocalCacheInvalidator
         // manifest from a boot-time snapshot (FileVersioner caches it per
         // instance) and silently revert every revision recorded since.
         $this->markAssetsDirty();
+    }
 
-        // Clear OPcache if available. Only effective for the SAPI we run in (a CLI
-        // subscriber cannot reset php-fpm's OPcache) — which is why the applied
-        // epoch is recorded per SAPI: php-fpm performs its own apply.
-        if (function_exists('opcache_reset')) {
-            opcache_reset();
+    /**
+     * Delete the compiled locale catalogues and invalidate their OPcache
+     * entries in this SAPI.
+     *
+     * The invalidation is belt-and-braces: Symfony re-invalidates a catalogue
+     * when it rewrites it, and from the CLI subscriber the call is a no-op
+     * (opcache.enable_cli is off by default). It replaces the previous global
+     * opcache_reset(), which forced the whole php-fpm pool to recompile
+     * everything mid-traffic — far more disruptive than the staleness it
+     * guarded against.
+     */
+    protected function clearLocaleCatalogues(): void
+    {
+        $files = glob($this->paths->storage.'/locale/*.php') ?: [];
+
+        $this->locales->clearCache();
+
+        if (!function_exists('opcache_invalidate')) {
+            return;
+        }
+
+        foreach ($files as $file) {
+            @opcache_invalidate($file, true);
         }
     }
 
@@ -136,8 +177,8 @@ class LocalCacheInvalidator
     /**
      * Atomically claim the right to apply an epoch, so concurrent php-fpm
      * workers crossing the same request boundary don't all run the full
-     * invalidation (N concurrent opcache resets). fopen('x') is the exclusive
-     * primitive; a stale claim from a crashed worker is broken after 60s.
+     * invalidation at once. fopen('x') is the exclusive primitive; a stale
+     * claim from a crashed worker is broken after 60s.
      */
     public function claimEpoch(int $version): bool
     {
@@ -185,8 +226,8 @@ class LocalCacheInvalidator
      * The epoch record lives in the base path (like the subscriber lock files),
      * suffixed by hostname AND SAPI: the hostname keeps records per pod even
      * when the install root is a volume shared between pods, and the SAPI
-     * keeps the CLI subscriber's apply from suppressing php-fpm's (whose
-     * opcache_reset is the only one that matters).
+     * keeps the CLI subscriber's apply from suppressing php-fpm's (OPcache is
+     * per process pool, so only php-fpm's own apply reaches its OPcache).
      */
     public function epochFilePath(): string
     {

--- a/src/Cache/LocalCacheInvalidator.php
+++ b/src/Cache/LocalCacheInvalidator.php
@@ -85,6 +85,14 @@ class LocalCacheInvalidator
         // The compiled locale catalogues are the exception: their filenames are
         // not derived from their contents, so nothing detects staleness and
         // deletion is the only way to force a rebuild from the YAML sources.
+        //
+        // markAssetsDirty() below calls markDirty(), which ALSO calls
+        // LocaleManager::clearCache() — so the deletion happens twice. Keep
+        // this call: it must run before the OPcache entries are invalidated
+        // (which needs the file list captured pre-deletion), and it keeps the
+        // apply correct even if a future core release stops clearing
+        // catalogues from markDirty() or markAssetsDirty() fails and is
+        // swallowed. The second deletion is a cheap no-op on an empty dir.
         $this->clearLocaleCatalogues();
 
         // Drop the shared settings cache as well: a concurrent refill that read the DB
@@ -115,8 +123,24 @@ class LocalCacheInvalidator
     }
 
     /**
-     * Delete the compiled locale catalogues and invalidate their OPcache
-     * entries in this SAPI.
+     * Delete the compiled locale catalogues and invalidate the OPcache entry of
+     * every PHP file among them in this SAPI.
+     *
+     * This is why an apply is needed at all on a pod that did not perform the
+     * admin action. Symfony names a compiled catalogue
+     * `catalogue.<locale>.<hash>.php`, where the hash covers only
+     * `fallback_locales` — NOT the translated content — and
+     * ConfigCache::isFresh() short-circuits to `is_file()` whenever debug is
+     * off, which is every production install. So a catalogue that predates a
+     * newly-enabled extension is considered fresh forever, and deleting the
+     * file is the only thing that forces a rebuild from the YAML sources.
+     *
+     * The file list is captured BEFORE clearCache() unlinks it, and is globbed
+     * as broadly as clearCache() itself (which deletes `/*`) so that a
+     * `.php.meta` sibling or any future compiled artefact is covered too;
+     * opcache_invalidate() is only meaningful for the PHP files, so non-PHP
+     * entries are filtered out rather than glob-restricted, which would have
+     * silently narrowed what we invalidate if Symfony changed its naming.
      *
      * The invalidation is belt-and-braces: Symfony re-invalidates a catalogue
      * when it rewrites it, and from the CLI subscriber the call is a no-op
@@ -127,7 +151,10 @@ class LocalCacheInvalidator
      */
     protected function clearLocaleCatalogues(): void
     {
-        $files = glob($this->paths->storage.'/locale/*.php') ?: [];
+        $files = array_filter(
+            glob($this->paths->storage.'/locale/*') ?: [],
+            fn (string $file) => str_ends_with($file, '.php')
+        );
 
         $this->locales->clearCache();
 

--- a/tests/integration/PubSubCacheInvalidationTest.php
+++ b/tests/integration/PubSubCacheInvalidationTest.php
@@ -51,6 +51,7 @@ class PubSubCacheInvalidationTest extends TestCase
         try {
             $paths = $this->app()->getContainer()->make(Paths::class);
             @array_map('unlink', glob($paths->base.'/cache-epoch-*') ?: []);
+            @array_map('unlink', glob($paths->storage.'/locale/catalogue.*.sentinel.php*') ?: []);
             @array_map('unlink', array_filter([
                 $paths->storage.'/formatter/Renderer_sentinel.php',
                 $paths->storage.'/views/sentinel.php',
@@ -147,10 +148,16 @@ class PubSubCacheInvalidationTest extends TestCase
 
         /** @var Paths $paths */
         $paths = $container->make(Paths::class);
-        // Only the locale catalogues may be deleted by an apply.
+        // Only the locale catalogues may be deleted by an apply. Seed them the
+        // way Symfony actually names them — `catalogue.<locale>.<hash>.php`
+        // plus its `.meta` sibling — so this exercises the real glob and the
+        // OPcache pass over the PHP file, not just a placeholder that any
+        // wildcard would match.
         @mkdir($paths->storage.'/locale', 0777, true);
-        $sentinel = $paths->storage.'/locale/sentinel.tmp';
-        file_put_contents($sentinel, 'stale catalogue');
+        $sentinel = $paths->storage.'/locale/catalogue.en.sentinel.php';
+        file_put_contents($sentinel, '<?php return [];');
+        $sentinelMeta = $sentinel.'.meta';
+        file_put_contents($sentinelMeta, 'stale catalogue metadata');
 
         // The file cache itself must be forgotten (the serialized formatter
         // lives there under `flarum.formatter`)...
@@ -195,6 +202,7 @@ class PubSubCacheInvalidationTest extends TestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertFileDoesNotExist($sentinel, 'A pod behind the epoch should clear its local caches before serving');
+        $this->assertFileDoesNotExist($sentinelMeta, 'The catalogue metadata must go with the catalogue, or Symfony reads a stale .meta');
         $this->assertSame($version, $invalidator->appliedVersion());
         $this->assertNull($fileCache->get('flarum.formatter'), 'An apply must forget the cached serialized formatter');
 
@@ -226,7 +234,7 @@ class PubSubCacheInvalidationTest extends TestCase
         /** @var Paths $paths */
         $paths = $container->make(Paths::class);
         @mkdir($paths->storage.'/locale', 0777, true);
-        $sentinel = $paths->storage.'/locale/sentinel.tmp';
+        $sentinel = $paths->storage.'/locale/catalogue.en.sentinel.php';
         file_put_contents($sentinel, 'fresh catalogue');
 
         $version = (int) round(microtime(true) * 1000);
@@ -256,7 +264,7 @@ class PubSubCacheInvalidationTest extends TestCase
         /** @var Paths $paths */
         $paths = $container->make(Paths::class);
         @mkdir($paths->storage.'/locale', 0777, true);
-        $sentinel = $paths->storage.'/locale/sentinel.tmp';
+        $sentinel = $paths->storage.'/locale/catalogue.en.sentinel.php';
         file_put_contents($sentinel, 'fresh pod');
 
         /** @var LocalCacheInvalidator $invalidator */

--- a/tests/integration/PubSubCacheInvalidationTest.php
+++ b/tests/integration/PubSubCacheInvalidationTest.php
@@ -23,6 +23,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\integration\TestCase;
 use FoF\Redis\Cache\LocalCacheInvalidator;
 use FoF\Redis\Middleware\DistributedCacheInvalidation;
+use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Redis\Factory;
 use Laminas\Diactoros\Response;
@@ -45,10 +46,17 @@ class PubSubCacheInvalidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // Remove per-pod epoch records and claims so no test inherits state.
+        // Remove per-pod epoch records and claims, and the sentinel files the
+        // apply test seeds, so no test inherits state.
         try {
-            $base = $this->app()->getContainer()->make(Paths::class)->base;
-            @array_map('unlink', glob($base.'/cache-epoch-*') ?: []);
+            $paths = $this->app()->getContainer()->make(Paths::class);
+            @array_map('unlink', glob($paths->base.'/cache-epoch-*') ?: []);
+            @array_map('unlink', array_filter([
+                $paths->storage.'/formatter/Renderer_sentinel.php',
+                $paths->storage.'/views/sentinel.php',
+                $paths->public.'/assets/forum.js',
+                $paths->public.'/assets/rev-manifest.json',
+            ], 'file_exists'));
         } catch (\Throwable $e) {
             // App may not have booted in this test.
         }
@@ -139,9 +147,37 @@ class PubSubCacheInvalidationTest extends TestCase
 
         /** @var Paths $paths */
         $paths = $container->make(Paths::class);
+        // Only the locale catalogues may be deleted by an apply.
         @mkdir($paths->storage.'/locale', 0777, true);
         $sentinel = $paths->storage.'/locale/sentinel.tmp';
         file_put_contents($sentinel, 'stale catalogue');
+
+        // The file cache itself must be forgotten (the serialized formatter
+        // lives there under `flarum.formatter`)...
+        $fileCache = new Repository($container->make('cache.filestore'));
+        $fileCache->forever('flarum.formatter', 'stale serialized formatter');
+
+        // ...but everything a concurrent request may still be using must
+        // survive: the formatter's renderer class files (deleting them
+        // mid-unserialize yields an incomplete object and a 500), the compiled
+        // Blade views, and the shared compiled assets with their revision
+        // manifest (2.x marks them dirty; it never flushes them). The manifest
+        // is seeded with a revision so a re-introduced flush would have
+        // something to act on.
+        @mkdir($paths->storage.'/formatter', 0777, true);
+        $formatterSentinel = $paths->storage.'/formatter/Renderer_sentinel.php';
+        file_put_contents($formatterSentinel, '<?php class Renderer_sentinel {}');
+
+        @mkdir($paths->storage.'/views', 0777, true);
+        $viewSentinel = $paths->storage.'/views/sentinel.php';
+        file_put_contents($viewSentinel, '<?php /* compiled view */');
+
+        @mkdir($paths->public.'/assets', 0777, true);
+        $manifest = $paths->public.'/assets/rev-manifest.json';
+        $manifestBefore = '{"forum.js":"sentinel"}';
+        file_put_contents($manifest, $manifestBefore);
+        $assetSentinel = $paths->public.'/assets/forum.js';
+        file_put_contents($assetSentinel, '/* compiled asset */');
 
         /** @var LocalCacheInvalidator $invalidator */
         $invalidator = $container->make(LocalCacheInvalidator::class);
@@ -160,6 +196,12 @@ class PubSubCacheInvalidationTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertFileDoesNotExist($sentinel, 'A pod behind the epoch should clear its local caches before serving');
         $this->assertSame($version, $invalidator->appliedVersion());
+        $this->assertNull($fileCache->get('flarum.formatter'), 'An apply must forget the cached serialized formatter');
+
+        $this->assertFileExists($formatterSentinel, 'An apply must not delete formatter class files a concurrent request may be unserializing');
+        $this->assertFileExists($viewSentinel, 'An apply must not delete compiled Blade views');
+        $this->assertFileExists($assetSentinel, 'An apply must not delete the shared compiled assets');
+        $this->assertSame($manifestBefore, file_get_contents($manifest), 'An apply must not rewrite the shared revision manifest');
 
         // The apply drops the poisoned snapshot; the asset-dirty writes that
         // follow may legitimately re-warm the cache FROM THE DATABASE (2.x's


### PR DESCRIPTION
2.x companion to #36 (1.x). Same diagnosis, three of its four changes — the fourth (shared-asset flush) was already solved on 2.x by #35's `markDirty()`.

## The problem

#35's apply handled the shared compiled assets correctly — it marks them dirty via core's `RecompileFrontendAssets::markDirty()` and never touches `rev-manifest.json` — but it kept three destructive steps from the `cache:clear`-style subscriber recipe this extension has used since v1.1.0 (#3), and #35 made them run **on every pod, on every settings save and extension toggle, in the request path, while visitors are mid-page**:

| Step | Why it hurts | Now |
|---|---|---|
| delete `storage/formatter/*` | The renderer class is autoloaded from that file *during* `unserialize()` of the cached formatter (`Formatter::getRenderer()`). Deleting it while another request is unserializing — a microsecond window, but opened twice per pod per admin action while the formatter is unserialized on every post render — leaves that request with an incomplete object; a method call on it throws `\Error`, **not** `\Exception`, so it escapes `BasicPostSerializer`'s `catch (Exception $e)` and becomes a 500. Core's own runtime refresh (`Formatter::flush()`, the Formatter extender) only forgets the cache entry; `cache:clear` sweeps the files. | **untouched** — the file cache is flushed, the class files stay. Residual, stated plainly: the class name is `Renderer_<sha1(generated php)>`, so a config-neutral rebuild rewrites the *same* file in place, non-atomically; OPcache normally serves the cached copy across that window. |
| delete `storage/views/*` | Compiled views are keyed by resolved source path and expire by source mtime, so another pod's can only be stale if a template *source* changed — toggles and saves never do that (deployments do, and those run `cache:clear`). Core does delete them on the acting pod for extensions with views; that's the acting pod's business. | **untouched** |
| `opcache_reset()` | Forces the whole php-fpm pool to recompile everything mid-traffic — more disruptive than the staleness it guarded against. Core never resets OPcache. | `opcache_invalidate()` on the locale files the apply still deletes. Belt-and-braces: Symfony re-invalidates a catalogue when it rewrites it, and from the CLI subscriber the call is a no-op. |

Unchanged: file-cache flush, locale catalogue deletion (the one cache whose filenames aren't content-derived — same microsecond window core's own `Extend\Locales` has on the acting pod), settings-cache forget, `markDirty()`, epoch record.

Net effect: **less code, fewer actions, no new machinery.** The 500 mechanism above is stated as the one this PR removes, not one reproduced in isolation — it needs real concurrency; see #36 for the production evidence and its limits.

## Docs

`DISTRIBUTED_CACHE.md` "What Gets Invalidated" now lists what an apply touches and what it deliberately leaves alone, with residuals; "Performance" states the real per-apply cost (formatter rebuild + catalogue recompile per pod, and that `Saved` triggers a full apply core does not need — #37). README FAQ updated.

## Tests

`middleware_applies_newer_epoch_and_clears_local_caches` pins the contract: after an apply the locale sentinel is gone and `flarum.formatter` is forgotten, while sentinels in `storage/formatter/`, `storage/views/`, `public/assets/forum.js` and the contents of `rev-manifest.json` are unchanged (the manifest is seeded with a revision so a re-introduced flush would have something to act on); seeded files are removed in `tearDown`. Red-before/green-after verified against the previous `src/`: the formatter sentinel assertion fails.

Local run (PHP 8.4, flarum/core 2.0.0-rc.8, MySQL 8 + Redis 7): PHPStan level 6 clean, unit 15/15, integration 69/69 twice back-to-back.

## Not in this PR

Follow-ups tracked in #37 (narrow the `Saved` apply) and #38 (atomic `VersionerInterface` — less relevant on 2.x, where `markDirty()` already avoids the manifest rewrite from the apply, but core's own flush path still does read-modify-writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
