### PR TITLE
[1.x] feat: store compiled-asset revisions in a Redis hash (atomic VersionerInterface)

### DIFF
--- a/DISTRIBUTED_CACHE.md
+++ b/DISTRIBUTED_CACHE.md
@@ -82,6 +82,10 @@ return [
             // 0 (default) checks on every request — one Redis GET, sub-millisecond.
             'check_interval' => 0,
         ],
+        // Where compiled-asset revisions are stored (see "Asset revisions in
+        // Redis" below): 'auto' (default — Redis when pub/sub is enabled,
+        // otherwise core's rev-manifest.json), 'redis', or 'file'.
+        'asset_revisions' => 'auto',
     ]))
 ];
 ```
@@ -161,8 +165,27 @@ Pub/sub alone is not safe here: delivery is asynchronous, so a request landing o
 3. Applying an epoch also re-flushes the compiled assets, so anything poisoned inside the tiny remaining in-flight window is erased as pods catch up
 4. Applying an epoch also drops the shared settings cache, so a pre-change snapshot re-stored by a racing refill lives milliseconds, not the full TTL
 5. Each pod applies independently and idempotently; concurrent workers on one pod are serialized by an atomic claim, and the applied epoch is recorded per pod (and per SAPI) so nothing is cleared twice
+6. With `asset_revisions` in Redis (the default when pub/sub is enabled), every revision write is a single atomic hash field, so concurrent writers — core's own flush on the acting pod and every pod's first rebuild — can no longer lose each other's updates (see below)
 
 **Residual window:** a request already past the epoch check when the invalidation lands can theoretically still write a stale asset after the last pod catches up. This is a tens-of-milliseconds sliver, and any later invalidation event heals it.
+
+### Asset revisions in Redis
+
+Core records which revision of each compiled asset is current in `rev-manifest.json`, next to the assets. Its `FileVersioner` updates that file with a **read-modify-write of the whole file**: read the JSON, change one key, write it all back. After an admin action several actors do that at once — core's flush on the acting pod is a dozen or so sequential writes (css, js and one locale css/js per locale, per frontend), and every pod's first render after the flush commits its own — so interleavings lose updates. Because `RevisionCompiler::getUrl()` only commits when a revision is *missing*, a lost update leaves a stale revision in place until the next admin action, and browsers and CDNs keep the stale URL. On assets stored on S3 each write is a network round trip, which makes the interleaving likely rather than exotic.
+
+Symptoms: an extension's settings page rendering empty right after enabling it (`admin.js` kept an old revision), a disable not reflected on the forum (`forum.js` did), or mixed states (`admin-de.js` advanced while `admin.js` did not).
+
+When pub/sub is enabled (or `'asset_revisions' => 'redis'` is set explicitly), this extension binds core's `VersionerInterface` to a Redis-backed versioner: the revisions live in one hash — `flarum:assets:revisions`, namespaced by the configured `prefix` like every other key on the cache connection — and every write is a single-field `HSET`/`HDEL`: atomic, no read-modify-write, nothing to lose. Core's `RevisionCompiler` accepts a versioner through the container, so **core's own flush uses it too**. Reads go to Redis on every call, like core's own versioner reads the manifest on every call (a handful of sub-millisecond `HGET`s per page render).
+
+What it does not change: the lazy rebuild-by-whoever-comes-next is core's design and stays; a request that booted before a toggle can still rebuild an asset from pre-change sources (see the residual window above).
+
+Operational notes:
+
+- **Requires the cache service.** The hash lives on the `fof.cache` connection; with `->disable(['cache'])` the setting has no effect and core's file stays in use.
+- **Split `connections` config:** in the "Completely separate the config array" form, `Configuration::for('cache')` uses the `connections.cache` block *instead of* the top level — so `asset_revisions` (like `pubsub` and `prefix`) must be placed **inside** `connections.cache`, or it is silently ignored.
+- **Switching over** is like a cache clear: the hash starts empty, so every asset is rebuilt once on its next request. `rev-manifest.json` is no longer read or written from then on — which means it **freezes**. If you ever switch back to `'file'`, run `php flarum cache:clear` right away: otherwise the frozen manifest hands out old `?v=` revisions for files whose contents have since changed, and browsers and CDNs keep serving the old bytes until the next admin action.
+- `php flarum cache:clear` (and the admin panel's *Clear Cache*) flush the cache connection's database (`FLUSHDB`) before core flushes the assets, which also empties the hash — the intended "rebuild everything" outcome of a cache clear. Under an `allkeys-*` eviction policy Redis may also evict the hash under memory pressure; the effect is the same as a cache clear (every asset rebuilt once).
+- **Errors are not swallowed.** A Redis error while reading or writing a revision surfaces as an error page, exactly like a storage error in core's own `FileVersioner` — and like the cache, settings and session stores this extension already puts on Redis. That is deliberate: a read failure reported as "no revision" would make core recompile on every request and then render pages without any CSS or JS, and a write failure reported as success would leave a stale revision in place with nothing to trigger a retry.
 
 ## Future Improvements
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ return [
 > **Important:** See "Use different database for each service" below to split up the database for cache vs sessions, queue
 > because a cache clear action will clear sessions and queue jobs as well if they share the same database.
 
+#### Asset revisions
+
+When pub/sub is enabled (multi-instance setups), the extension also stores the compiled-asset revisions core normally keeps in `rev-manifest.json` in a Redis hash, because concurrent writes to that file lose updates and leave stale assets in place. Control it with `'asset_revisions' => 'auto' | 'redis' | 'file'` (default `'auto'`). Details, trade-offs and operational notes in [DISTRIBUTED_CACHE.md](DISTRIBUTED_CACHE.md#asset-revisions-in-redis).
+
 #### Advanced configuration
 
 1. Disable specific services:

--- a/src/Assets/RedisVersioner.php
+++ b/src/Assets/RedisVersioner.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Assets;
+
+use Flarum\Frontend\Compiler\VersionerInterface;
+use Illuminate\Contracts\Redis\Factory;
+
+/**
+ * Stores compiled-asset revisions in a Redis hash instead of rev-manifest.json.
+ *
+ * Core's FileVersioner updates the manifest with a read-modify-write of the
+ * whole file: read the JSON, change one key, write the JSON back. Several
+ * actors do that concurrently after an admin action — core's flush on the
+ * acting pod is a dozen or so sequential writes, and every pod's first render
+ * after the flush commits its own — so interleavings lose updates. Because
+ * RevisionCompiler::getUrl() only commits when a revision is MISSING, a lost
+ * update leaves a stale revision in place until the next admin action, and
+ * browsers and CDNs keep the stale URL. Symptoms: an extension's settings page
+ * empty right after enabling it, a disable not reflected on the forum, mixed
+ * old/new locale assets.
+ *
+ * A Redis hash makes every write a single-field atomic operation (HSET/HDEL),
+ * so concurrent writers cannot clobber each other. The lazy
+ * rebuild-by-whoever-comes-next is unchanged — that is core's design.
+ *
+ * Reads go to Redis on every call, exactly like core's 1.x FileVersioner reads
+ * the manifest file on every call (a handful of sub-millisecond HGETs per page
+ * render). No memo, so a long-lived process such as the cache:subscribe
+ * command can never hold a stale view.
+ *
+ * Errors propagate, exactly like FileVersioner's storage errors. That is
+ * deliberate: a read failure reported as "no revision" would make
+ * RevisionCompiler::getUrl() recompile on every request and then return null,
+ * rendering pages without any CSS or JS; a write failure reported as success
+ * would leave a stale revision in the hash with nothing to trigger a retry.
+ * A Redis error here surfaces as an error page instead, the same way it does
+ * for the cache, settings and session stores this extension puts on Redis.
+ */
+class RedisVersioner implements VersionerInterface
+{
+    const KEY = 'flarum:assets:revisions';
+
+    /**
+     * @var Factory
+     */
+    protected $redis;
+
+    /**
+     * @var string
+     */
+    protected $connection;
+
+    /**
+     * @var string
+     */
+    protected $key;
+
+    public function __construct(Factory $redis, string $connection, string $key = self::KEY)
+    {
+        $this->redis = $redis;
+        $this->connection = $connection;
+        $this->key = $key;
+    }
+
+    public function putRevision(string $file, ?string $revision)
+    {
+        if ($revision) {
+            $this->redis->connection($this->connection)->hset($this->key, $file, $revision);
+        } else {
+            $this->redis->connection($this->connection)->hdel($this->key, $file);
+        }
+    }
+
+    public function getRevision(string $file): ?string
+    {
+        // phpredis returns false for a missing field, Predis returns null.
+        $revision = $this->redis->connection($this->connection)->hget($this->key, $file);
+
+        return is_string($revision) && $revision !== '' ? $revision : null;
+    }
+
+    /**
+     * Every recorded revision, keyed by asset file name.
+     *
+     * Not part of the 1.x VersionerInterface; provided for diagnostics and tests.
+     *
+     * @return array<string, string>
+     */
+    public function allRevisions(): array
+    {
+        $revisions = [];
+
+        foreach ((array) $this->redis->connection($this->connection)->hgetall($this->key) as $file => $revision) {
+            if (is_string($revision) && $revision !== '') {
+                $revisions[(string) $file] = $revision;
+            }
+        }
+
+        return $revisions;
+    }
+}

--- a/src/Provides/Cache.php
+++ b/src/Provides/Cache.php
@@ -17,7 +17,9 @@ use Flarum\Extension\Event\Disabled;
 use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
+use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Settings\Event\Saved;
+use FoF\Redis\Assets\RedisVersioner;
 use FoF\Redis\Cache\LocalCacheInvalidator;
 use FoF\Redis\Configuration;
 use FoF\Redis\Event\CacheConnectionReady;
@@ -45,7 +47,7 @@ class Cache extends Provider
         );
 
         $connectionConfig = $rawConfig;
-        Arr::forget($connectionConfig, ['pubsub']);
+        Arr::forget($connectionConfig, ['pubsub', 'asset_revisions']);
 
         $container->resolving(Factory::class, function (Factory $manager) use ($connectionConfig) {
             /** @var RedisManager $manager */
@@ -82,6 +84,28 @@ class Cache extends Provider
         });
 
         $container->alias('cache.redisstore', Store::class);
+
+        // Compiled-asset revisions: core's FileVersioner updates rev-manifest.json
+        // with a non-atomic read-modify-write, and after an admin action several
+        // actors write it concurrently (core's flush on the acting pod, every
+        // pod's first rebuild) — interleavings lose updates and leave stale
+        // revisions in place until the next admin action. A Redis hash makes each
+        // write a single atomic field. Core's RevisionCompiler takes an optional
+        // VersionerInterface and is built through the container, so binding one
+        // here means core's compilers — and core's own flush — use it too.
+        if ($this->normalizeAssetRevisions(Arr::get($rawConfig, 'asset_revisions'), $pubSubConfig['enabled']) === 'redis') {
+            // Like every other key on this connection, the client applies the
+            // configured prefix again on the wire.
+            $prefix = Arr::get($rawConfig, 'prefix', '');
+
+            $container->singleton(VersionerInterface::class, function (Container $container) use ($prefix) {
+                return new RedisVersioner(
+                    $container->make(Factory::class),
+                    $this->connection,
+                    $prefix.RedisVersioner::KEY
+                );
+            });
+        }
 
         $publishInvalidation = function () use ($container, $pubSubConfig) {
             if (!$pubSubConfig['enabled']) {
@@ -163,6 +187,26 @@ class Cache extends Provider
                 return $exclude;
             });
         }
+    }
+
+    /**
+     * Where compiled-asset revisions live: 'redis' or 'file'.
+     *
+     * 'auto' (the default, and any unrecognised value) follows pub/sub: the
+     * manifest race only matters when several instances write it, which is
+     * exactly when pub/sub is on. Single-instance setups keep core's file.
+     *
+     * @param mixed $value
+     */
+    private function normalizeAssetRevisions($value, bool $pubSubEnabled): string
+    {
+        $value = is_string($value) ? strtolower(trim($value)) : 'auto';
+
+        if ($value === 'redis' || $value === 'file') {
+            return $value;
+        }
+
+        return $pubSubEnabled ? 'redis' : 'file';
     }
 
     private function normalizePubSubConfig(array $config, string $prefix = ''): array

--- a/tests/integration/AssetRevisionsTest.php
+++ b/tests/integration/AssetRevisionsTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Frontend\Compiler\FileVersioner;
+use Flarum\Frontend\Compiler\JsCompiler;
+use Flarum\Frontend\Compiler\VersionerInterface;
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Assets\RedisVersioner;
+use FoF\Redis\Extend\Redis as RedisExtender;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Redis\Factory;
+
+class AssetRevisionsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // Remove what the tests wrote, whatever prefix it landed under.
+        try {
+            $raw = $this->rawRedis();
+            foreach ($raw->keys('*'.RedisVersioner::KEY) as $key) {
+                $raw->del($key);
+            }
+        } catch (\Throwable $e) {
+            // Redis unavailable — nothing to clean.
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function with_pubsub_enabled_the_redis_versioner_is_bound_by_default()
+    {
+        $this->registerRedis();
+        $this->requiresRedis();
+
+        $container = $this->app()->getContainer();
+
+        $this->assertTrue($container->bound(VersionerInterface::class));
+        $this->assertInstanceOf(RedisVersioner::class, $container->make(VersionerInterface::class));
+        $this->assertSame(
+            $container->make(VersionerInterface::class),
+            $container->make(VersionerInterface::class),
+            'The versioner is a singleton — one Redis client path, no per-compiler instances'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function core_compilers_receive_the_redis_versioner()
+    {
+        $this->registerRedis();
+        $this->requiresRedis();
+
+        $this->assertInstanceOf(
+            RedisVersioner::class,
+            $this->versionerOfAFreshCompiler(),
+            'RevisionCompiler\'s optional VersionerInterface must be satisfied by the container binding, not by its FileVersioner default'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function revisions_round_trip_through_the_configured_redis_connection()
+    {
+        $this->registerRedis();
+        $this->requiresRedis();
+
+        $container = $this->app()->getContainer();
+        /** @var RedisVersioner $versioner */
+        $versioner = $container->make(VersionerInterface::class);
+
+        $versioner->putRevision('forum.js', 'deadbeef');
+        $versioner->putRevision('forum-de.js', 'cafe');
+
+        $this->assertSame('deadbeef', $versioner->getRevision('forum.js'));
+        $this->assertSame(['forum.js' => 'deadbeef', 'forum-de.js' => 'cafe'], $versioner->allRevisions());
+
+        // Stored as a single hash on the cache connection — one atomic field per asset.
+        $raw = $container->make(Factory::class)->connection('fof.cache')->hgetall(RedisVersioner::KEY);
+        $this->assertSame(['forum.js' => 'deadbeef', 'forum-de.js' => 'cafe'], $raw);
+
+        $versioner->putRevision('forum.js', null);
+        $this->assertNull($versioner->getRevision('forum.js'));
+        $this->assertSame(['forum-de.js' => 'cafe'], $container->make(Factory::class)->connection('fof.cache')->hgetall(RedisVersioner::KEY));
+    }
+
+    /**
+     * @test
+     */
+    public function two_instances_write_independent_fields_and_a_fresh_reader_sees_both()
+    {
+        // Documentation-by-test: atomicity itself comes from HSET/HDEL being
+        // single-field commands (pinned in the unit test); this shows the
+        // resulting semantics against real Redis.
+        $this->registerRedis();
+        $this->requiresRedis();
+
+        $redis = $this->app()->getContainer()->make(Factory::class);
+
+        $a = new RedisVersioner($redis, 'fof.cache');
+        $b = new RedisVersioner($redis, 'fof.cache');
+
+        $a->putRevision('forum.js', 'from-a');
+        $b->putRevision('admin.js', 'from-b');
+
+        $this->assertSame('from-a', $b->getRevision('forum.js'), 'No memo on 1.x: B sees A\'s write on its next read');
+        $this->assertSame(
+            ['forum.js' => 'from-a', 'admin.js' => 'from-b'],
+            (new RedisVersioner($redis, 'fof.cache'))->allRevisions()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function core_compilers_record_their_revisions_in_the_hash_end_to_end()
+    {
+        $this->registerRedis();
+        $this->requiresRedis();
+
+        // Exactly what Content\Assets does when rendering a page: getUrl()
+        // finds no revision, compiles, records one, and returns a busted URL.
+        $forum = $this->app()->getContainer()->make('flarum.assets.forum');
+        $jsUrl = $forum->makeJs()->getUrl();
+        $cssUrl = $forum->makeCss()->getUrl();
+
+        $this->assertStringContainsString('forum.js?v=', (string) $jsUrl);
+        $this->assertStringContainsString('forum.css?v=', (string) $cssUrl);
+
+        $recorded = $this->rawRedis()->hgetall(RedisVersioner::KEY);
+
+        $this->assertArrayHasKey('forum.js', $recorded, 'The JS compiler must have written its revision to the Redis hash, not to rev-manifest.json');
+        $this->assertArrayHasKey('forum.css', $recorded, 'The LESS compiler must have written its revision to the Redis hash, not to rev-manifest.json');
+        $this->assertStringEndsWith('?v='.$recorded['forum.js'], $jsUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function the_file_versioner_can_be_kept_explicitly()
+    {
+        $this->registerRedis(['asset_revisions' => 'file']);
+        $this->requiresRedis();
+
+        $this->assertFalse($this->app()->getContainer()->bound(VersionerInterface::class));
+        $this->assertInstanceOf(FileVersioner::class, $this->versionerOfAFreshCompiler());
+    }
+
+    /**
+     * @test
+     */
+    public function without_pubsub_the_file_versioner_stays_unless_opted_in()
+    {
+        $this->registerRedis(['pubsub' => ['enabled' => false, 'autostart' => false]]);
+        $this->requiresRedis();
+
+        $this->assertFalse($this->app()->getContainer()->bound(VersionerInterface::class));
+        $this->assertInstanceOf(FileVersioner::class, $this->versionerOfAFreshCompiler());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_opted_in_without_pubsub()
+    {
+        $this->registerRedis(['pubsub' => ['enabled' => false, 'autostart' => false], 'asset_revisions' => 'redis']);
+        $this->requiresRedis();
+
+        $this->assertInstanceOf(RedisVersioner::class, $this->versionerOfAFreshCompiler());
+    }
+
+    /**
+     * @test
+     */
+    public function the_hash_key_is_isolated_by_the_configured_prefix()
+    {
+        $this->registerRedis(['prefix' => 'site-a:']);
+        $this->requiresRedis();
+
+        $this->app()->getContainer()->make(VersionerInterface::class)->putRevision('forum.js', 'v1');
+
+        // Read through a RAW client (no client-side prefix), so this can fail if
+        // the key is not actually namespaced on the wire. The client applies the
+        // configured prefix on top of the one the extension prepends, which is
+        // the same convention every other key on this connection follows.
+        $keys = $this->rawRedis()->keys('*'.RedisVersioner::KEY);
+
+        $this->assertCount(1, $keys);
+        $this->assertStringStartsWith('site-a:', $keys[0]);
+        $this->assertStringEndsWith(RedisVersioner::KEY, $keys[0]);
+        $this->assertSame(['forum.js' => 'v1'], $this->rawRedis()->hgetall($keys[0]));
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    /**
+     * A client on the test database with NO prefix and no app involvement, to
+     * observe what is actually stored.
+     *
+     * @return \Redis|\Predis\Client
+     */
+    private function rawRedis()
+    {
+        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+        $port = (int) (getenv('REDIS_PORT') ?: 6379);
+
+        if (extension_loaded('redis')) {
+            $client = new \Redis();
+            $client->connect($host, $port);
+            $client->select(15);
+
+            return $client;
+        }
+
+        return new \Predis\Client(['scheme' => 'tcp', 'host' => $host, 'port' => $port, 'database' => 15]);
+    }
+
+    /**
+     * Register the extender the way the other 1.x tests do, with pub/sub on
+     * by default; $overrides replace top-level keys.
+     */
+    private function registerRedis(array $overrides = []): void
+    {
+        $this->extend(
+            new RedisExtender(array_replace([
+                'host'     => getenv('REDIS_HOST') ?: '127.0.0.1',
+                'password' => getenv('REDIS_PASSWORD') ?: null,
+                'port'     => getenv('REDIS_PORT') ?: 6379,
+                'database' => 15,
+                'pubsub'   => [
+                    'enabled'   => true,
+                    'autostart' => false,
+                ],
+            ], $overrides))
+        );
+    }
+
+    /**
+     * The versioner core's compilers actually end up with: resolve a JsCompiler
+     * exactly like Frontend\Assets does and read the property it was built with.
+     */
+    private function versionerOfAFreshCompiler(): VersionerInterface
+    {
+        $container = $this->app()->getContainer();
+
+        $compiler = $container->make(JsCompiler::class, [
+            'assetsDir' => $container->make(FilesystemFactory::class)->disk('flarum-assets'),
+            'filename'  => 'forum.js',
+        ]);
+
+        $property = new \ReflectionProperty($compiler, 'versioner');
+        $property->setAccessible(true);
+
+        return $property->getValue($compiler);
+    }
+
+    private function requiresRedis(): void
+    {
+        try {
+            $result = $this->app()->getContainer()->make(Factory::class)->connection('fof.cache')->ping();
+
+            if ($result === false || ((string) $result !== 'PONG' && $result !== true)) {
+                $this->markTestSkipped('Redis is not available: ping returned '.var_export($result, true));
+            }
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('Redis is not available: '.$e->getMessage());
+        }
+    }
+}

--- a/tests/unit/CacheAssetRevisionsConfigTest.php
+++ b/tests/unit/CacheAssetRevisionsConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\unit;
+
+use FoF\Redis\Provides\Cache;
+use PHPUnit\Framework\TestCase;
+
+class CacheAssetRevisionsConfigTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function auto_follows_pubsub()
+    {
+        $this->assertSame('redis', $this->normalize(null, true));
+        $this->assertSame('file', $this->normalize(null, false));
+        $this->assertSame('redis', $this->normalize('auto', true));
+        $this->assertSame('file', $this->normalize('auto', false));
+    }
+
+    /**
+     * @test
+     */
+    public function explicit_values_win_over_pubsub()
+    {
+        $this->assertSame('file', $this->normalize('file', true));
+        $this->assertSame('redis', $this->normalize('redis', false));
+        $this->assertSame('redis', $this->normalize(' Redis ', false));
+    }
+
+    /**
+     * @test
+     */
+    public function unrecognised_values_fall_back_to_auto()
+    {
+        $this->assertSame('redis', $this->normalize('yes', true));
+        $this->assertSame('file', $this->normalize(true, false));
+        $this->assertSame('file', $this->normalize(['redis'], false));
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function normalize($value, bool $pubSubEnabled): string
+    {
+        $cache = new Cache();
+        $method = (new \ReflectionClass($cache))->getMethod('normalizeAssetRevisions');
+        $method->setAccessible(true);
+
+        return $method->invoke($cache, $value, $pubSubEnabled);
+    }
+}

--- a/tests/unit/RedisVersionerTest.php
+++ b/tests/unit/RedisVersionerTest.php
@@ -1,0 +1,243 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\unit;
+
+use FoF\Redis\Assets\RedisVersioner;
+use Illuminate\Contracts\Redis\Factory;
+use PHPUnit\Framework\TestCase;
+
+class RedisVersionerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_stores_reads_and_removes_revisions()
+    {
+        $versioner = $this->versioner($this->hash());
+
+        $this->assertNull($versioner->getRevision('forum.js'));
+
+        $versioner->putRevision('forum.js', 'abc123');
+        $this->assertSame('abc123', $versioner->getRevision('forum.js'));
+
+        $versioner->putRevision('forum.js', null);
+        $this->assertNull($versioner->getRevision('forum.js'));
+        $this->assertSame([], $versioner->allRevisions());
+    }
+
+    /**
+     * @test
+     */
+    public function reads_are_never_stale_across_instances()
+    {
+        $hash = $this->hash();
+        $a = $this->versioner($hash);
+        $b = $this->versioner($hash);
+
+        $this->assertNull($a->getRevision('forum.js'));
+
+        $b->putRevision('forum.js', 'v1');
+
+        // No memo on 1.x: A sees B's write on its very next read.
+        $this->assertSame('v1', $a->getRevision('forum.js'));
+    }
+
+    /**
+     * @test
+     */
+    public function the_write_path_only_ever_issues_single_field_commands()
+    {
+        // Atomicity comes from the command choice: a per-field HSET/HDEL cannot
+        // lose a concurrent writer's update, whereas anything that reads the
+        // whole hash and writes it back (HGETALL + HMSET/DEL) can. Pin the
+        // commands the write path uses, so a refactor towards read-modify-write
+        // fails this test.
+        $hash = $this->hash();
+        $versioner = $this->versioner($hash);
+
+        $versioner->putRevision('forum.js', 'v1');
+        $versioner->putRevision('admin.js', null);
+
+        $this->assertSame(['hset', 'hdel'], array_column($hash->log, 0));
+    }
+
+    /**
+     * @test
+     */
+    public function two_instances_write_independent_fields_and_a_fresh_reader_sees_both()
+    {
+        $hash = $this->hash();
+        $a = $this->versioner($hash);
+        $b = $this->versioner($hash);
+
+        $a->putRevision('forum.js', 'from-a');
+        $b->putRevision('admin.js', 'from-b');
+
+        $this->assertSame(['forum.js' => 'from-a', 'admin.js' => 'from-b'], $hash->store[RedisVersioner::KEY]);
+        $this->assertSame(['forum.js' => 'from-a', 'admin.js' => 'from-b'], $this->versioner($hash)->allRevisions());
+    }
+
+    /**
+     * @test
+     */
+    public function redis_errors_propagate_on_read()
+    {
+        // Like FileVersioner's storage errors: RevisionCompiler::getUrl() treats
+        // "no revision" as "recompile, and if still none, render without the
+        // asset" — a swallowed read error would mean pages without CSS/JS.
+        $versioner = $this->versioner($this->broken());
+
+        $this->expectException(\RuntimeException::class);
+        $versioner->getRevision('forum.js');
+    }
+
+    /**
+     * @test
+     */
+    public function redis_errors_propagate_on_write()
+    {
+        // A swallowed write error would leave a stale revision in the hash with
+        // nothing to trigger a retry — stale content until the next admin action.
+        $versioner = $this->versioner($this->broken());
+
+        $this->expectException(\RuntimeException::class);
+        $versioner->putRevision('forum.js', 'v1');
+    }
+
+    /**
+     * @test
+     */
+    public function a_missing_field_reads_as_no_revision_with_either_client()
+    {
+        // phpredis returns false for a missing hash field, Predis returns null.
+        $hash = $this->hash();
+        $hash->missingFieldValue = false;
+        $this->assertNull($this->versioner($hash)->getRevision('forum.js'));
+
+        $hash->missingFieldValue = null;
+        $this->assertNull($this->versioner($hash)->getRevision('forum.js'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_empty_or_non_string_values_from_redis()
+    {
+        $hash = $this->hash();
+        $hash->store[RedisVersioner::KEY] = ['forum.js' => 'ok', 'admin.js' => '', 'x.js' => null];
+
+        $versioner = $this->versioner($hash);
+
+        $this->assertSame(['forum.js' => 'ok'], $versioner->allRevisions());
+        $this->assertNull($versioner->getRevision('admin.js'));
+        $this->assertNull($versioner->getRevision('x.js'));
+    }
+
+    /**
+     * @test
+     */
+    public function the_key_is_configurable_for_prefixing()
+    {
+        $hash = $this->hash();
+        $versioner = new RedisVersioner($this->factory($hash), 'fof.cache', 'site-a:'.RedisVersioner::KEY);
+
+        $versioner->putRevision('forum.js', 'v1');
+
+        $this->assertArrayHasKey('site-a:'.RedisVersioner::KEY, $hash->store);
+        $this->assertArrayNotHasKey(RedisVersioner::KEY, $hash->store);
+    }
+
+    // --- fakes -----------------------------------------------------------
+
+    protected function versioner($connection): RedisVersioner
+    {
+        return new RedisVersioner($this->factory($connection), 'fof.cache', RedisVersioner::KEY);
+    }
+
+    protected function factory($connection): Factory
+    {
+        return new class($connection) implements Factory {
+            /** @var object */
+            protected $connection;
+
+            public function __construct($connection)
+            {
+                $this->connection = $connection;
+            }
+
+            public function connection($name = null)
+            {
+                return $this->connection;
+            }
+        };
+    }
+
+    /**
+     * In-memory stand-in for the subset of Redis hash commands the versioner
+     * uses, recording every command it receives.
+     */
+    protected function hash()
+    {
+        return new class() {
+            /** @var array<string, array<string, mixed>> */
+            public $store = [];
+
+            /** @var array<int, array<int, string>> command name + key */
+            public $log = [];
+
+            /** @var mixed what HGET returns for a missing field (false on phpredis, null on Predis) */
+            public $missingFieldValue = null;
+
+            public function hget(string $key, string $field)
+            {
+                $this->log[] = ['hget', $key];
+
+                return array_key_exists($field, $this->store[$key] ?? []) ? $this->store[$key][$field] : $this->missingFieldValue;
+            }
+
+            public function hgetall(string $key): array
+            {
+                $this->log[] = ['hgetall', $key];
+
+                return $this->store[$key] ?? [];
+            }
+
+            public function hset(string $key, string $field, string $value): int
+            {
+                $this->log[] = ['hset', $key];
+                $this->store[$key][$field] = $value;
+
+                return 1;
+            }
+
+            public function hdel(string $key, string $field): int
+            {
+                $this->log[] = ['hdel', $key];
+                unset($this->store[$key][$field]);
+
+                return 1;
+            }
+        };
+    }
+
+    protected function broken()
+    {
+        return new class() {
+            public function __call(string $method, array $arguments)
+            {
+                throw new \RuntimeException('Connection refused');
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes issue #38. Follow-up to PR #36 — that PR stopped this extension's *extra* writers on `rev-manifest.json`; this one removes the race itself.

## The problem

Core records the current revision of each compiled asset in `rev-manifest.json` and updates it with a **read-modify-write of the whole file** (`FileVersioner::putRevision()`: read JSON → change one key → write JSON). After an admin action several actors do that concurrently: core's flush on the acting pod is a dozen or so sequential writes (css, js, one locale css/js per locale, per frontend), and every pod's first render after the flush commits its own. Interleavings lose updates, and because `RevisionCompiler::getUrl()` only commits when a revision is *missing*, a lost update leaves a stale revision in place until the next admin action — browsers and CDNs keep the stale URL.

Seen in production (3 pods, assets on S3 via flysystem, CloudFront): an extension's settings page rendering empty right after enabling it (`admin.js` kept an old revision), a disable not reflected on the forum (`forum.js` did), mixed states (`admin-de.js` advanced while `admin.js` did not). On S3 each write is a network round trip, so the interleaving is likely rather than exotic. #36 brought this back to core's baseline rate; the baseline is not zero.

## The change

`RevisionCompiler::__construct(Cloud $assetsDir, string $filename, VersionerInterface $versioner = null)` is built via `resolve()` (`Frontend\Assets::makeJs()/makeCss()`), and Illuminate's container tries `make(VersionerInterface::class)` before falling back to the default — so a container binding is injected into **every** compiler, core's own flush included. This PR binds a Redis-backed versioner:

- one hash, `flarum:assets:revisions`, on the existing `fof.cache` connection, namespaced by the configured `prefix` like every other key there;
- every write is a single-field `HSET` / `HDEL` — atomic, no read-modify-write, nothing to lose;
- reads go to Redis on every call, matching 1.x's `FileVersioner` (reads the file on every call): a handful of sub-millisecond `HGET`s per page render, no memo, so the long-running `cache:subscribe` process can never hold a stale view;
- **errors propagate**, exactly like `FileVersioner`'s storage errors. Deliberate: `getUrl()` treats "no revision" as "recompile, and if still none, drop the asset" (`Content\Assets::getUrls()` filters the `null`), so a read failure reported as "no revision" would mean a full recompile + S3 write per request *and* pages without any CSS or JS; a swallowed write failure would leave a stale revision in the hash with nothing to trigger a retry. A Redis error surfaces as an error page instead — as it already does for the cache, settings and session stores this extension puts on Redis.

New config key `asset_revisions`: `'auto'` (default — Redis when pub/sub is enabled, otherwise core's file, since the race only matters when several instances write), `'redis'`, or `'file'`. In the split `connections` config form it must live **inside** `connections.cache` — `Configuration::for()` replaces the array with that block on 1.x (same as `pubsub`/`prefix`; now documented).

What it does **not** change: the lazy rebuild-by-whoever-comes-next is core's design and stays (2.x defers it via `markDirty()`); a request that booted just before a toggle can still rebuild from pre-change sources. This removes the *lost-update* half of the manifest race.

## Operational notes

- Switching over behaves like a cache clear: the hash starts empty, every asset is rebuilt once. `rev-manifest.json` is no longer read *or written* — it **freezes** — so switching back to `'file'` requires a `cache:clear`, otherwise the frozen manifest hands out old `?v=` for new bytes.
- `php flarum cache:clear` runs `cache->flush()` (FLUSHDB on the cache connection) *before* dispatching `ClearingCache`, so it also empties the hash — the intended outcome. The epoch key from #34 is written after that flush, so it is unaffected. Eviction under `allkeys-*` has the same effect as a cache clear.
- Requires the cache service (`->disable(['cache'])` leaves core's file in use).
- **Requires shared asset storage** (S3/flysystem or a shared volume), like the rest of the multi-instance setup. The manifest used to live next to the assets, so a pod that had a revision also had the file; with the revision in Redis that coupling is gone — a pod compiling into a pod-local `assets/` directory would hand out `?v=` URLs for files it never wrote.

## Tests

- `tests/unit/RedisVersionerTest.php` — recording in-memory fake: round trip; cross-instance freshness; **the write path issues only `HSET`/`HDEL`** (a refactor towards read-modify-write fails it); errors propagate on read and on write; phpredis `false` vs Predis `null` for a missing field both read as "no revision"; empty/non-string values ignored; prefixed key.
- `tests/unit/CacheAssetRevisionsConfigTest.php` — `auto` follows pub/sub, explicit values win, garbage falls back to auto.
- `tests/integration/AssetRevisionsTest.php` — against real Redis: bound as a singleton when pub/sub is on; a `JsCompiler` resolved the way `Frontend\Assets` does receives it; **end-to-end: `flarum.assets.forum`'s `makeJs()->getUrl()` and `makeCss()->getUrl()` record `forum.js`/`forum.css` in the hash and return busted URLs**; round trip; two instances write independent fields; `'file'` keeps `FileVersioner`; pub/sub off → file unless explicit; prefix isolation observed through a raw, unprefixed client.

Local: PHPStan level 5 clean; unit 23/23; integration 21/21 twice; `php -l` under real PHP 7.3 (docker) clean for the new source. Reviewed twice independently before opening; the first design swallowed Redis errors and was reversed for the reasons above.

## Belongs elsewhere (flarum/framework 1.x)

- `FileVersioner::putRevision()` non-atomic read-modify-write — the root cause.
- `VersionerInterface` has no error channel: `RevisionCompiler::getUrl()` returns `null` when a revision is missing after `commit()`, and the page silently ships without that asset.

Note: touches `DISTRIBUTED_CACHE.md`'s "Race Conditions?" list and residual paragraph, which #36 also rewrites (it literally names this versioner as "a candidate follow-up"); whichever lands second needs a small prose rebase.

Merge order matters for the fail-closed guarantee: on 1.x the pre-existing `LocalCacheInvalidator::flushCompiledAssets()` wraps the epoch-apply asset flush in `catch (\Throwable)` (meant for unbound frontends), which would also swallow a versioner error and let the epoch be recorded as applied. #36 removes that method. Land #36 first, or narrow that catch to `BindingResolutionException` alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
