### PR TITLE
[2.x] feat: store compiled-asset revisions in a Redis hash (atomic VersionerInterface)

### DIFF
--- a/DISTRIBUTED_CACHE.md
+++ b/DISTRIBUTED_CACHE.md
@@ -82,6 +82,10 @@ return [
             // 0 (default) checks on every request — one Redis GET, sub-millisecond.
             'check_interval' => 0,
         ],
+        // Where compiled-asset revisions are stored (see "Asset revisions in
+        // Redis" below): 'auto' (default — Redis when pub/sub is enabled,
+        // otherwise core's rev-manifest.json), 'redis', or 'file'.
+        'asset_revisions' => 'auto',
     ]))
 ];
 ```
@@ -161,8 +165,26 @@ Pub/sub alone is not safe here: delivery is asynchronous, so a request landing o
 3. Applying an epoch also re-flushes the compiled assets, so anything poisoned inside the tiny remaining in-flight window is erased as pods catch up
 4. Applying an epoch also drops the shared settings cache, so a pre-change snapshot re-stored by a racing refill lives milliseconds, not the full TTL
 5. Each pod applies independently and idempotently (no locks needed); the applied epoch is recorded per pod so nothing is cleared twice
+6. With `asset_revisions` in Redis (the default when pub/sub is enabled), every revision write is a single atomic hash field, so the pods rebuilding a dirty asset set concurrently can no longer lose each other's updates (see below)
 
 **Residual window:** a request already past the epoch check when the invalidation lands can theoretically still write a stale artifact after the last pod catches up. This is a tens-of-milliseconds sliver, and any later invalidation event heals it.
+
+### Asset revisions in Redis
+
+Core records which revision of each compiled asset is current in `rev-manifest.json`, next to the assets. Its `FileVersioner` updates that file with a **read-modify-write of the whole file**: read the JSON, change one key, write it all back. On 2.x the writers race each other after an admin action: core marks every asset set *dirty* (`RecompileFrontendAssets::markDirty()`), and the next page **or API** request on *each* pod rebuilds the set in place (`recompileIfDirty()`) before the shared dirty flag is cleared — so several pods commit at once, each rewriting the manifest, and interleavings lose updates. Because `RevisionCompiler::getUrl()` only commits when a revision is *missing*, a lost update leaves a stale revision in place until the next admin action, and browsers and CDNs keep the stale URL. On assets stored on S3 each write is a network round trip, which makes the interleaving likely rather than exotic.
+
+Symptoms: an extension's settings page rendering empty right after enabling it (`admin.js` kept an old revision), a disable not reflected on the forum (`forum.js` did), or mixed states (`admin-de.js` advanced while `admin.js` did not).
+
+When pub/sub is enabled (or `'asset_revisions' => 'redis'` is set explicitly), this extension rebinds core's `VersionerInterface` to a Redis-backed versioner: the revisions live in one hash — `flarum:assets:revisions`, namespaced by the configured `prefix` like every other key on the cache connection — and every write is a single-field `HSET`/`HDEL`: atomic, no read-modify-write, nothing to lose. Core's compilers, `Document` (the `revisions` payload for split chunks) and the assets-revision header all receive it through the container. Reads are memoised per request like core's versioner (one `HGETALL`).
+
+What it does not change: the lazy rebuild-by-whoever-comes-next is core's design and stays; a request that booted before a toggle can still rebuild an asset from pre-change sources (see the residual window above).
+
+Operational notes:
+
+- **Requires the cache service.** The hash lives on the `fof.cache` connection; with `->disable(['cache'])` the setting has no effect and core's file stays in use.
+- **Switching over** is like a cache clear: the hash starts empty, so every asset is rebuilt once on its next request. `rev-manifest.json` is no longer read or written from then on — which means it **freezes**. If you ever switch back to `'file'`, run `php flarum cache:clear` right away: otherwise the frozen manifest hands out old `?v=` revisions for files whose contents have since changed, and browsers and CDNs keep serving the old bytes until the next admin action.
+- `php flarum cache:clear` (and the admin panel's *Clear Cache*) flush the cache connection's database (`FLUSHDB`) before core marks the assets dirty, which also empties the hash — the intended "rebuild everything" outcome of a cache clear. Under an `allkeys-*` eviction policy Redis may also evict the hash under memory pressure; the effect is the same as a cache clear (every asset rebuilt once).
+- **Errors are not swallowed.** A Redis error while reading or writing a revision surfaces as an error page, exactly like a storage error in core's own `FileVersioner` — and like the cache, settings and session stores this extension already puts on Redis. That is deliberate: `recompileIfDirty()` clears the dirty flag right after a rebuild reports success, so a write failure hidden from core would leave the *old* revision in the hash for good; and a read failure reported as "no revision" would make core recompile on every request and then render pages without any CSS or JS.
 
 ## Future Improvements
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ return [
 > See "Use different database for each service" below to split up the database for cache vs sessions, queue
 > because a cache clear action will clear sessions and queue jobs as well if they share the same database.
 
+#### Asset revisions
+
+When pub/sub is enabled (multi-instance setups), the extension also stores the compiled-asset revisions core normally keeps in `rev-manifest.json` in a Redis hash, because concurrent writes to that file lose updates and leave stale assets in place. Control it with `'asset_revisions' => 'auto' | 'redis' | 'file'` (default `'auto'`). Details, trade-offs and operational notes in [DISTRIBUTED_CACHE.md](DISTRIBUTED_CACHE.md#asset-revisions-in-redis).
+
 #### Advanced configuration
 
 1. Disable specific services:

--- a/src/Assets/RedisVersioner.php
+++ b/src/Assets/RedisVersioner.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Assets;
+
+use Flarum\Frontend\Compiler\VersionerInterface;
+use Illuminate\Contracts\Redis\Factory;
+
+/**
+ * Stores compiled-asset revisions in a Redis hash instead of rev-manifest.json.
+ *
+ * Core's FileVersioner updates the manifest with a read-modify-write of the
+ * whole file: read the JSON, change one key, write the JSON back. On 2.x the
+ * writers race each other after an admin action: core marks every asset set
+ * dirty, and the next page or API request on EACH pod rebuilds it in place
+ * (RecompileFrontendAssets::recompileIfDirty()) — several pods commit at once,
+ * and interleaved read-modify-writes lose updates. Because
+ * RevisionCompiler::getUrl() only commits when a revision is MISSING, a lost
+ * update leaves a stale revision in place until the next admin action, and
+ * browsers and CDNs keep the stale URL. Symptoms: an extension's settings page
+ * empty right after enabling it, a disable not reflected on the forum, mixed
+ * old/new locale assets.
+ *
+ * A Redis hash makes every write a single-field atomic operation (HSET/HDEL),
+ * so concurrent writers cannot clobber each other. The lazy
+ * rebuild-by-whoever-comes-next is unchanged — that is core's design.
+ *
+ * Reads are memoised per instance, exactly like core's FileVersioner (one
+ * HGETALL per request for the singleton); writes update the memo.
+ *
+ * Errors propagate, exactly like FileVersioner's storage errors. That is
+ * deliberate: RecompileFrontendAssets::recompileIfDirty() clears the shared
+ * dirty flag right after a successful rebuild, so a write failure reported as
+ * success would consume the flag while the hash still holds the OLD revision —
+ * stale content served until the next admin action, the very bug this class
+ * exists to remove. And a read failure reported as "no revision" would make
+ * RevisionCompiler::getUrl() recompile on every request and then return null,
+ * rendering pages without any CSS or JS. A Redis error here surfaces as an
+ * error page instead, the same way it does for the cache, settings and
+ * session stores this extension puts on Redis.
+ */
+class RedisVersioner implements VersionerInterface
+{
+    public const string KEY = 'flarum:assets:revisions';
+
+    /**
+     * @var array<string, string>|null
+     */
+    protected ?array $revisions = null;
+
+    public function __construct(
+        protected Factory $redis,
+        protected string $connection,
+        protected string $key = self::KEY
+    ) {
+    }
+
+    public function putRevision(string $file, ?string $revision): void
+    {
+        if ($revision) {
+            $this->redis->connection($this->connection)->hset($this->key, $file, $revision);
+        } else {
+            $this->redis->connection($this->connection)->hdel($this->key, $file);
+        }
+
+        if ($this->revisions === null) {
+            return;
+        }
+
+        if ($revision) {
+            $this->revisions[$file] = $revision;
+        } else {
+            unset($this->revisions[$file]);
+        }
+    }
+
+    public function getRevision(string $file): ?string
+    {
+        return $this->allRevisions()[$file] ?? null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function allRevisions(): array
+    {
+        if ($this->revisions !== null) {
+            return $this->revisions;
+        }
+
+        $revisions = [];
+
+        // phpredis and Predis both return an associative array here; values
+        // are strings, but guard against anything else a misconfigured key
+        // could yield rather than hand core a non-string revision.
+        foreach ((array) $this->redis->connection($this->connection)->hgetall($this->key) as $file => $revision) {
+            if (is_string($revision) && $revision !== '') {
+                $revisions[(string) $file] = $revision;
+            }
+        }
+
+        return $this->revisions = $revisions;
+    }
+}

--- a/src/Provides/Cache.php
+++ b/src/Provides/Cache.php
@@ -17,7 +17,9 @@ use Flarum\Extension\Event\Disabled;
 use Flarum\Extension\Event\Enabled;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
+use Flarum\Frontend\Compiler\VersionerInterface;
 use Flarum\Settings\Event\Saved;
+use FoF\Redis\Assets\RedisVersioner;
 use FoF\Redis\Cache\LocalCacheInvalidator;
 use FoF\Redis\Configuration;
 use FoF\Redis\Event\CacheConnectionReady;
@@ -45,7 +47,7 @@ class Cache extends Provider
         );
 
         $connectionConfig = $rawConfig;
-        Arr::forget($connectionConfig, ['pubsub']);
+        Arr::forget($connectionConfig, ['pubsub', 'asset_revisions']);
 
         $container->resolving(Factory::class, function (Factory $manager) use ($connectionConfig) {
             /** @var RedisManager $manager */
@@ -82,6 +84,29 @@ class Cache extends Provider
         });
 
         $container->alias('cache.redisstore', Store::class);
+
+        // Compiled-asset revisions: core's FileVersioner updates rev-manifest.json
+        // with a non-atomic read-modify-write. After an admin action core marks
+        // every asset set dirty and the next page or API request on EACH pod
+        // rebuilds it in place, so several pods commit concurrently —
+        // interleavings lose updates and leave stale revisions in place until
+        // the next admin action. A Redis hash makes each write a single atomic
+        // field. Rebinding core's VersionerInterface (core registers a
+        // FileVersioner singleton; extenders run after every register()) means
+        // core's compilers, Document and the assets-revision header all use it.
+        if ($this->normalizeAssetRevisions(Arr::get($rawConfig, 'asset_revisions'), $pubSubConfig['enabled']) === 'redis') {
+            // Like every other key on this connection, the client applies the
+            // configured prefix again on the wire.
+            $prefix = Arr::get($rawConfig, 'prefix', '');
+
+            $container->singleton(VersionerInterface::class, function (Container $container) use ($prefix) {
+                return new RedisVersioner(
+                    $container->make(Factory::class),
+                    $this->connection,
+                    $prefix.RedisVersioner::KEY
+                );
+            });
+        }
 
         $publishInvalidation = function () use ($container, $pubSubConfig) {
             if (!$pubSubConfig['enabled']) {
@@ -164,6 +189,24 @@ class Cache extends Provider
                 return $exclude;
             });
         }
+    }
+
+    /**
+     * Where compiled-asset revisions live: 'redis' or 'file'.
+     *
+     * 'auto' (the default, and any unrecognised value) follows pub/sub: the
+     * manifest race only matters when several instances write it, which is
+     * exactly when pub/sub is on. Single-instance setups keep core's file.
+     */
+    private function normalizeAssetRevisions(mixed $value, bool $pubSubEnabled): string
+    {
+        $value = is_string($value) ? strtolower(trim($value)) : 'auto';
+
+        if ($value === 'redis' || $value === 'file') {
+            return $value;
+        }
+
+        return $pubSubEnabled ? 'redis' : 'file';
     }
 
     private function normalizePubSubConfig(array $config, string $prefix = ''): array

--- a/tests/integration/AssetRevisionsTest.php
+++ b/tests/integration/AssetRevisionsTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\integration;
+
+use Flarum\Frontend\Compiler\FileVersioner;
+use Flarum\Frontend\Compiler\JsCompiler;
+use Flarum\Frontend\Compiler\VersionerInterface;
+use Flarum\Testing\integration\TestCase;
+use FoF\Redis\Assets\RedisVersioner;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Redis\Factory;
+use PHPUnit\Framework\Attributes\Test;
+
+class AssetRevisionsTest extends TestCase
+{
+    use RedisTestConfig;
+
+    protected function tearDown(): void
+    {
+        $this->flushTestDatabases();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function with_pubsub_enabled_the_redis_versioner_is_bound_by_default()
+    {
+        $this->registerRedis();
+
+        $container = $this->app()->getContainer();
+
+        $this->assertInstanceOf(RedisVersioner::class, $container->make(VersionerInterface::class));
+        $this->assertSame(
+            $container->make(VersionerInterface::class),
+            $container->make(VersionerInterface::class),
+            'The versioner must be a singleton so the per-request memo is shared'
+        );
+    }
+
+    #[Test]
+    public function core_compilers_receive_the_redis_versioner()
+    {
+        $this->registerRedis();
+
+        $container = $this->app()->getContainer();
+
+        $compiler = $container->make(JsCompiler::class, [
+            'assetsDir' => $container->make(FilesystemFactory::class)->disk('flarum-assets'),
+            'filename'  => 'forum.js',
+        ]);
+
+        $versioner = (new \ReflectionProperty($compiler, 'versioner'))->getValue($compiler);
+
+        $this->assertInstanceOf(RedisVersioner::class, $versioner, 'RevisionCompiler must be built with the Redis versioner, not core\'s FileVersioner');
+    }
+
+    #[Test]
+    public function revisions_round_trip_through_the_configured_redis_connection()
+    {
+        $this->registerRedis();
+
+        $container = $this->app()->getContainer();
+        /** @var RedisVersioner $versioner */
+        $versioner = $container->make(VersionerInterface::class);
+
+        $versioner->putRevision('forum.js', 'deadbeef');
+        $versioner->putRevision('forum-de.js', 'cafe');
+
+        $this->assertSame('deadbeef', $versioner->getRevision('forum.js'));
+        $this->assertSame(['forum.js' => 'deadbeef', 'forum-de.js' => 'cafe'], $versioner->allRevisions());
+
+        // Stored as a single hash on the cache connection — one atomic field per asset.
+        $raw = $container->make(Factory::class)->connection('fof.cache')->hgetall(RedisVersioner::KEY);
+        $this->assertSame(['forum.js' => 'deadbeef', 'forum-de.js' => 'cafe'], $raw);
+
+        $versioner->putRevision('forum.js', null);
+        $this->assertNull($versioner->getRevision('forum.js'));
+        $this->assertSame(['forum-de.js' => 'cafe'], $container->make(Factory::class)->connection('fof.cache')->hgetall(RedisVersioner::KEY));
+    }
+
+    #[Test]
+    public function two_instances_write_independent_fields_and_a_fresh_reader_sees_both()
+    {
+        // Documentation-by-test: atomicity itself comes from HSET/HDEL being
+        // single-field commands (pinned in the unit test); this shows the
+        // resulting semantics against real Redis.
+        $this->registerRedis();
+
+        $container = $this->app()->getContainer();
+        $redis = $container->make(Factory::class);
+
+        $a = new RedisVersioner($redis, 'fof.cache');
+        $b = new RedisVersioner($redis, 'fof.cache');
+        $a->allRevisions();
+        $b->allRevisions();
+
+        $a->putRevision('forum.js', 'from-a');
+        $b->putRevision('admin.js', 'from-b');
+
+        $this->assertSame(
+            ['forum.js' => 'from-a', 'admin.js' => 'from-b'],
+            (new RedisVersioner($redis, 'fof.cache'))->allRevisions()
+        );
+    }
+
+    #[Test]
+    public function core_compilers_record_their_revisions_in_the_hash_end_to_end()
+    {
+        $this->registerRedis();
+
+        $container = $this->app()->getContainer();
+        // Resolve the registered abstract directly: core's AssetManager::frontend()
+        // checks in_array() against the map's VALUES, so frontend('forum') throws
+        // "Unknown frontend" for every registered frontend (core 2.x bug).
+        $forum = $container->make('flarum.assets.forum');
+
+        // Exactly what Content\Assets does when rendering a page: getUrl()
+        // finds no revision, compiles, records one, and returns a busted URL.
+        $jsUrl = $forum->makeJs()->getUrl();
+        $cssUrl = $forum->makeCss()->getUrl();
+
+        $this->assertStringContainsString('forum.js?v=', (string) $jsUrl);
+        $this->assertStringContainsString('forum.css?v=', (string) $cssUrl);
+
+        $recorded = $this->rawRedis($this->testCacheDb)->hgetall(RedisVersioner::KEY);
+
+        $this->assertArrayHasKey('forum.js', $recorded, 'The JS compiler must have written its revision to the Redis hash, not to rev-manifest.json');
+        $this->assertArrayHasKey('forum.css', $recorded, 'The LESS compiler must have written its revision to the Redis hash, not to rev-manifest.json');
+        $this->assertStringEndsWith('?v='.$recorded['forum.js'], $jsUrl);
+    }
+
+    #[Test]
+    public function the_file_versioner_can_be_kept_explicitly()
+    {
+        $this->registerRedis([], ['asset_revisions' => 'file']);
+
+        $this->assertInstanceOf(FileVersioner::class, $this->app()->getContainer()->make(VersionerInterface::class));
+    }
+
+    #[Test]
+    public function without_pubsub_the_file_versioner_stays_unless_opted_in()
+    {
+        $this->registerRedis([], ['pubsub' => ['enabled' => false, 'autostart' => false]]);
+
+        $this->assertInstanceOf(FileVersioner::class, $this->app()->getContainer()->make(VersionerInterface::class));
+    }
+
+    #[Test]
+    public function it_can_be_opted_in_without_pubsub()
+    {
+        $this->registerRedis([], ['pubsub' => ['enabled' => false, 'autostart' => false], 'asset_revisions' => 'redis']);
+
+        $this->assertInstanceOf(RedisVersioner::class, $this->app()->getContainer()->make(VersionerInterface::class));
+    }
+
+    #[Test]
+    public function the_hash_key_is_isolated_by_the_configured_prefix()
+    {
+        $this->registerRedis([], ['prefix' => 'site-a:']);
+
+        $this->app()->getContainer()->make(VersionerInterface::class)->putRevision('forum.js', 'v1');
+
+        // Read through a RAW client (no client-side prefix), so this can fail if
+        // the key is not actually namespaced on the wire. The client applies the
+        // configured prefix on top of the one the extension prepends, which is
+        // the same convention every other key on this connection follows.
+        $keys = $this->rawRedis($this->testCacheDb)->keys('*'.RedisVersioner::KEY);
+
+        $this->assertCount(1, $keys);
+        $this->assertStringStartsWith('site-a:', $keys[0]);
+        $this->assertStringEndsWith(RedisVersioner::KEY, $keys[0]);
+        $this->assertSame(['forum.js' => 'v1'], $this->rawRedis($this->testCacheDb)->hgetall($keys[0]));
+    }
+}

--- a/tests/integration/RedisTestConfig.php
+++ b/tests/integration/RedisTestConfig.php
@@ -61,10 +61,11 @@ trait RedisTestConfig
      * Register the Redis extender with all services pinned to test databases.
      *
      * @param array $queueConfig extra keys merged into the `queue` config block
+     * @param array $overrides   top-level keys replacing those of redisConfig()
      */
-    protected function registerRedis(array $queueConfig = []): void
+    protected function registerRedis(array $queueConfig = [], array $overrides = []): void
     {
-        $config = $this->redisConfig();
+        $config = array_replace($this->redisConfig(), $overrides);
         $config['queue'] = array_merge($config['queue'] ?? [], $queueConfig);
 
         $this->extend(

--- a/tests/unit/CacheAssetRevisionsConfigTest.php
+++ b/tests/unit/CacheAssetRevisionsConfigTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\unit;
+
+use FoF\Redis\Provides\Cache;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class CacheAssetRevisionsConfigTest extends TestCase
+{
+    #[Test]
+    public function auto_follows_pubsub()
+    {
+        $this->assertSame('redis', $this->normalize(null, true));
+        $this->assertSame('file', $this->normalize(null, false));
+        $this->assertSame('redis', $this->normalize('auto', true));
+        $this->assertSame('file', $this->normalize('auto', false));
+    }
+
+    #[Test]
+    public function explicit_values_win_over_pubsub()
+    {
+        $this->assertSame('file', $this->normalize('file', true));
+        $this->assertSame('redis', $this->normalize('redis', false));
+        $this->assertSame('redis', $this->normalize(' Redis ', false));
+    }
+
+    #[Test]
+    public function unrecognised_values_fall_back_to_auto()
+    {
+        $this->assertSame('redis', $this->normalize('yes', true));
+        $this->assertSame('file', $this->normalize(true, false));
+        $this->assertSame('file', $this->normalize(['redis'], false));
+    }
+
+    private function normalize(mixed $value, bool $pubSubEnabled): string
+    {
+        $method = (new \ReflectionClass(Cache::class))->getMethod('normalizeAssetRevisions');
+
+        return $method->invoke(new Cache(), $value, $pubSubEnabled);
+    }
+}

--- a/tests/unit/RedisVersionerTest.php
+++ b/tests/unit/RedisVersionerTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of fof/redis.
+ *
+ * Copyright (c) Bokt.
+ * Copyright (c) Blomstra Ltd.
+ * Copyright (c) FriendsOfFlarum
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Redis\Tests\unit;
+
+use FoF\Redis\Assets\RedisVersioner;
+use Illuminate\Contracts\Redis\Factory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class RedisVersionerTest extends TestCase
+{
+    #[Test]
+    public function it_stores_reads_and_removes_revisions()
+    {
+        $versioner = $this->versioner($this->hash());
+
+        $this->assertNull($versioner->getRevision('forum.js'));
+
+        $versioner->putRevision('forum.js', 'abc123');
+        $this->assertSame('abc123', $versioner->getRevision('forum.js'));
+
+        $versioner->putRevision('forum.js', null);
+        $this->assertNull($versioner->getRevision('forum.js'));
+        $this->assertSame([], $versioner->allRevisions());
+    }
+
+    #[Test]
+    public function writes_keep_the_memoised_read_in_sync()
+    {
+        $versioner = $this->versioner($this->hash());
+
+        // Prime the memo.
+        $this->assertSame([], $versioner->allRevisions());
+
+        $versioner->putRevision('forum.js', 'v1');
+        $versioner->putRevision('admin.js', 'v2');
+        $this->assertSame(['forum.js' => 'v1', 'admin.js' => 'v2'], $versioner->allRevisions());
+
+        $versioner->putRevision('forum.js', null);
+        $this->assertSame(['admin.js' => 'v2'], $versioner->allRevisions());
+    }
+
+    #[Test]
+    public function the_write_path_only_ever_issues_single_field_commands()
+    {
+        // Atomicity comes from the command choice: a per-field HSET/HDEL cannot
+        // lose a concurrent writer's update, whereas anything that reads the
+        // whole hash and writes it back (HGETALL + HMSET/DEL) can. Pin the
+        // commands the write path uses, so a refactor towards read-modify-write
+        // fails this test.
+        $hash = $this->hash();
+        $versioner = $this->versioner($hash);
+
+        $versioner->allRevisions(); // prime the memo — writes must not need a read afterwards
+        $hash->log = [];
+
+        $versioner->putRevision('forum.js', 'v1');
+        $versioner->putRevision('admin.js', null);
+
+        $this->assertSame(['hset', 'hdel'], array_column($hash->log, 0));
+    }
+
+    #[Test]
+    public function two_instances_write_independent_fields_and_a_fresh_reader_sees_both()
+    {
+        $hash = $this->hash();
+        $a = $this->versioner($hash);
+        $b = $this->versioner($hash);
+
+        $a->allRevisions();
+        $b->allRevisions();
+
+        $a->putRevision('forum.js', 'from-a');
+        $b->putRevision('admin.js', 'from-b');
+
+        $this->assertSame(['forum.js' => 'from-a', 'admin.js' => 'from-b'], $hash->store[RedisVersioner::KEY]);
+        $this->assertSame(['forum.js' => 'from-a', 'admin.js' => 'from-b'], $this->versioner($hash)->allRevisions());
+    }
+
+    #[Test]
+    public function redis_errors_propagate_on_read()
+    {
+        // Like FileVersioner's storage errors: RevisionCompiler::getUrl() treats
+        // "no revision" as "recompile, and if still none, render without the
+        // asset" — a swallowed read error would mean pages without CSS/JS.
+        $versioner = $this->versioner($this->broken());
+
+        $this->expectException(\RuntimeException::class);
+        $versioner->getRevision('forum.js');
+    }
+
+    #[Test]
+    public function redis_errors_propagate_on_write()
+    {
+        // RecompileFrontendAssets::recompileIfDirty() clears the shared dirty
+        // flag right after commitAll() returns. A swallowed write error would
+        // consume the flag while the hash still holds the old revision — stale
+        // content served until the next admin action.
+        $versioner = $this->versioner($this->broken());
+
+        $this->expectException(\RuntimeException::class);
+        $versioner->putRevision('forum.js', 'v1');
+    }
+
+    #[Test]
+    public function it_ignores_empty_or_non_string_values_from_redis()
+    {
+        $hash = $this->hash();
+        // '' and null: defensive; false: what phpredis returns for a missing
+        // field on HGET (not used here, but keep the guard honest).
+        $hash->store[RedisVersioner::KEY] = ['forum.js' => 'ok', 'admin.js' => '', 'x.js' => null, 'y.js' => false];
+
+        $this->assertSame(['forum.js' => 'ok'], $this->versioner($hash)->allRevisions());
+    }
+
+    #[Test]
+    public function the_key_is_configurable_for_prefixing()
+    {
+        $hash = $this->hash();
+        $versioner = new RedisVersioner($this->factory($hash), 'fof.cache', 'site-a:'.RedisVersioner::KEY);
+
+        $versioner->putRevision('forum.js', 'v1');
+
+        $this->assertArrayHasKey('site-a:'.RedisVersioner::KEY, $hash->store);
+        $this->assertArrayNotHasKey(RedisVersioner::KEY, $hash->store);
+    }
+
+    // --- fakes -----------------------------------------------------------
+
+    protected function versioner(object $connection): RedisVersioner
+    {
+        return new RedisVersioner($this->factory($connection), 'fof.cache', RedisVersioner::KEY);
+    }
+
+    protected function factory(object $connection): Factory
+    {
+        return new class($connection) implements Factory {
+            public function __construct(protected object $connection)
+            {
+            }
+
+            public function connection($name = null)
+            {
+                return $this->connection;
+            }
+        };
+    }
+
+    /**
+     * In-memory stand-in for the subset of Redis hash commands the versioner
+     * uses, recording every command it receives.
+     */
+    protected function hash(): object
+    {
+        return new class() {
+            /** @var array<string, array<string, mixed>> */
+            public array $store = [];
+
+            /** @var list<array{0: string, 1: string}> command name + key */
+            public array $log = [];
+
+            public function hgetall(string $key): array
+            {
+                $this->log[] = ['hgetall', $key];
+
+                return $this->store[$key] ?? [];
+            }
+
+            public function hset(string $key, string $field, string $value): int
+            {
+                $this->log[] = ['hset', $key];
+                $this->store[$key][$field] = $value;
+
+                return 1;
+            }
+
+            public function hdel(string $key, string $field): int
+            {
+                $this->log[] = ['hdel', $key];
+                unset($this->store[$key][$field]);
+
+                return 1;
+            }
+        };
+    }
+
+    protected function broken(): object
+    {
+        return new class() {
+            public function __call(string $method, array $arguments): mixed
+            {
+                throw new \RuntimeException('Connection refused');
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes issue #38 for the `2.x` line — companion to the 1.x PR.

## The problem

Core records the current revision of each compiled asset in `rev-manifest.json` and updates it with a **read-modify-write of the whole file** (`FileVersioner::putRevision()`). On 2.x the writers race each other after an admin action: core marks every asset set *dirty* (`RecompileFrontendAssets::markDirty()`), and the next page **or API** request on *each* pod rebuilds it in place (`recompileIfDirty()`) before the shared dirty flag is cleared — so several pods commit at once, each rewriting the manifest, and interleavings lose updates. Because `RevisionCompiler::getUrl()` only commits when a revision is *missing*, a lost update leaves a stale revision in place until the next admin action — browsers and CDNs keep the stale URL.

Symptoms: an extension's settings page rendering empty right after enabling it, a disable not reflected on the forum, mixed locale states. On S3-backed assets each write is a network round trip, so the interleaving is likely rather than exotic.

## The change

Core 2.x binds `VersionerInterface` to a `FileVersioner` singleton in `FrontendServiceProvider::register()` and injects it into every compiler, `Document` (the `revisions` payload for split chunks) and `AssetsRevision` (the assets-revision header). Extenders run after every `register()`, so this PR's rebinding wins and all of those receive a Redis-backed versioner:

- one hash, `flarum:assets:revisions`, on the existing `fof.cache` connection, namespaced by the configured `prefix` like every other key there;
- every write is a single-field `HSET` / `HDEL` — atomic, no read-modify-write, nothing to lose;
- reads are memoised per instance, matching core's 2.x `FileVersioner` (one `HGETALL` per request for the singleton); writes update the memo; `allRevisions()` is served from it;
- **errors propagate**, exactly like `FileVersioner`'s storage errors. This matters more on 2.x: `recompileIfDirty()` deletes the shared dirty flag right after `commitAll()` returns, so a swallowed write failure would *consume the flag while the hash still holds the old revision* — stale content served until the next admin action, i.e. the very bug this PR removes, reintroduced by a safety net. And a read failure reported as "no revision" would make `getUrl()` recompile per request and then return `null` (pages without CSS/JS) while `AssetsRevision::token()` hashes an empty map and prompts every open tab to reload. A Redis error surfaces as an error page instead — as it already does for the cache, settings and session stores this extension puts on Redis.

New config key `asset_revisions`: `'auto'` (default — Redis when pub/sub is enabled, otherwise core's file), `'redis'`, or `'file'`. On 2.x `Configuration::for()` merges the per-service block over the top level, so the key works in either config form.

What it does **not** change: the lazy rebuild-by-whoever-comes-next is core's design and stays (2.x already defers it to a freshly-booted request via `markDirty()`/`recompileIfDirty()`). This removes the *lost-update* half of the manifest race.

## Operational notes

- Switching over behaves like a cache clear: the hash starts empty, every asset is rebuilt once. `rev-manifest.json` is no longer read *or written* — it **freezes** — so switching back to `'file'` requires a `cache:clear`, otherwise the frozen manifest hands out old `?v=` for new bytes (2.x heals on the next `markDirty()`, but not before).
- `php flarum cache:clear` runs `cache->flush()` (FLUSHDB on the cache connection) *before* dispatching `ClearingCache`, so it also empties the hash — the intended outcome. The epoch key from #35 is written after that flush, so it is unaffected. Eviction under `allkeys-*` has the same effect as a cache clear.
- Requires the cache service (`->disable(['cache'])` leaves core's file in use).
- **Requires shared asset storage** (S3/flysystem or a shared volume), like the rest of the multi-instance setup. The manifest used to live next to the assets, so a pod that had a revision also had the file; with the revision in Redis that coupling is gone — a pod compiling into a pod-local `assets/` directory would hand out `?v=` URLs for files it never wrote.

## Tests

- `tests/unit/RedisVersionerTest.php` — recording in-memory fake: round trip; memo kept in sync by writes; **the write path issues only `HSET`/`HDEL`** (a refactor towards read-modify-write fails it); errors propagate on read and on write; empty/non-string values ignored; prefixed key.
- `tests/unit/CacheAssetRevisionsConfigTest.php` — `auto` follows pub/sub, explicit values win, garbage falls back to auto.
- `tests/integration/AssetRevisionsTest.php` — against real Redis: bound as a singleton when pub/sub is on; a `JsCompiler` resolved the way `Frontend\Assets` does receives it; **end-to-end: `flarum.assets.forum`'s `makeJs()->getUrl()` and `makeCss()->getUrl()` record `forum.js`/`forum.css` in the hash and return busted URLs**; round trip; two instances write independent fields; `'file'` keeps `FileVersioner`; pub/sub off → file unless explicit; prefix isolation observed through a raw, unprefixed client.

Local (PHP 8.4, flarum/core 2.0.0-rc.8): PHPStan level 6 clean; unit 26/26; integration 78/78 twice. Reviewed twice independently before opening; the first design swallowed Redis errors and was reversed for the reasons above.

## Belongs elsewhere (flarum/framework 2.x)

- `AssetManager::frontend()` checks `in_array($frontend, $this->assets)` against the map's **values**, so `frontend('forum')` throws "Unknown frontend" for every registered frontend (should be `array_key_exists`). The test resolves `flarum.assets.forum` directly to work around it.
- `FileVersioner::putRevision()` non-atomic read-modify-write — the root cause.
- `RecompileFrontendAssets::recompileIfDirty()` has no mutual exclusion: every pod's page *and API* request in the window rebuilds concurrently.
- `RevisionCompiler::getUrl()` returns `null` when a revision is missing after `commit()`, silently dropping the asset from the page; `AssetsRevision::tokenFor([])` treats an empty manifest as a real state.

Note: touches `DISTRIBUTED_CACHE.md`'s "Race Conditions?" list, which #39 also edits nearby; whichever lands second needs a small prose rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
