### PR TITLE
[2.x] fix: stop deleting the locale catalogues core already deletes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "flarum/core": "^2.0.0-rc.6",
+        "flarum/core": "2.x-dev",
         "illuminate/redis": "^13.0",
         "predis/predis": "^v2.3.0"
     },

--- a/src/Cache/LocalCacheInvalidator.php
+++ b/src/Cache/LocalCacheInvalidator.php
@@ -82,18 +82,21 @@ class LocalCacheInvalidator
         // which toggles and settings saves never do (deployments do, and
         // those run cache:clear).
 
-        // The compiled locale catalogues are the exception: their filenames are
-        // not derived from their contents, so nothing detects staleness and
-        // deletion is the only way to force a rebuild from the YAML sources.
+        // Invalidate the OPcache entry of every compiled locale catalogue.
         //
-        // markAssetsDirty() below calls markDirty(), which ALSO calls
-        // LocaleManager::clearCache() — so the deletion happens twice. Keep
-        // this call: it must run before the OPcache entries are invalidated
-        // (which needs the file list captured pre-deletion), and it keeps the
-        // apply correct even if a future core release stops clearing
-        // catalogues from markDirty() or markAssetsDirty() fails and is
-        // swallowed. The second deletion is a cheap no-op on an empty dir.
-        $this->clearLocaleCatalogues();
+        // The deletion itself is core's: markAssetsDirty() below calls
+        // markDirty(), which calls LocaleManager::clearCache(). Since core
+        // 2.0 a catalogue also carries a `.revision` sidecar that
+        // CatalogueCache compares per request, so an instance that never
+        // received a message works out for itself that its catalogue is stale
+        // — this apply is no longer what makes translations correct.
+        //
+        // What core does not do is tell OPcache. A catalogue is a PHP file
+        // Symfony rewrites at the same path, so a cached entry can shadow the
+        // new contents in this SAPI until the file's timestamp is re-checked.
+        // The list has to be captured before core unlinks the files, which is
+        // why this runs first.
+        $catalogues = $this->localeCatalogues();
 
         // Drop the shared settings cache as well: a concurrent refill that read the DB
         // just before the invalidating write can re-store a pre-change snapshot AFTER
@@ -120,44 +123,46 @@ class LocalCacheInvalidator
         // manifest from a boot-time snapshot (FileVersioner caches it per
         // instance) and silently revert every revision recorded since.
         $this->markAssetsDirty();
+
+        $this->invalidateOpcache($catalogues);
     }
 
     /**
-     * Delete the compiled locale catalogues and invalidate the OPcache entry of
-     * every PHP file among them in this SAPI.
+     * The compiled locale catalogues, as they stand before core deletes them.
      *
-     * This is why an apply is needed at all on a pod that did not perform the
-     * admin action. Symfony names a compiled catalogue
-     * `catalogue.<locale>.<hash>.php`, where the hash covers only
-     * `fallback_locales` — NOT the translated content — and
-     * ConfigCache::isFresh() short-circuits to `is_file()` whenever debug is
-     * off, which is every production install. So a catalogue that predates a
-     * newly-enabled extension is considered fresh forever, and deleting the
-     * file is the only thing that forces a rebuild from the YAML sources.
+     * Captured up front because the OPcache entries are keyed by path and the
+     * files are about to be unlinked — after that there is nothing left to
+     * enumerate.
      *
-     * The file list is captured BEFORE clearCache() unlinks it, and is globbed
-     * as broadly as clearCache() itself (which deletes `/*`) so that a
-     * `.php.meta` sibling or any future compiled artefact is covered too;
-     * opcache_invalidate() is only meaningful for the PHP files, so non-PHP
-     * entries are filtered out rather than glob-restricted, which would have
-     * silently narrowed what we invalidate if Symfony changed its naming.
-     *
-     * The invalidation is belt-and-braces: Symfony re-invalidates a catalogue
-     * when it rewrites it, and from the CLI subscriber the call is a no-op
-     * (opcache.enable_cli is off by default). It replaces the previous global
-     * opcache_reset(), which forced the whole php-fpm pool to recompile
-     * everything mid-traffic — far more disruptive than the staleness it
-     * guarded against.
+     * @return list<string>
      */
-    protected function clearLocaleCatalogues(): void
+    protected function localeCatalogues(): array
     {
-        $files = array_filter(
+        // Globbed as broadly as LocaleManager::clearCache() itself (which
+        // deletes `/*`) so a `.php.meta` sibling or any future compiled
+        // artefact is covered too; opcache_invalidate() is only meaningful
+        // for the PHP files, so non-PHP entries are filtered out rather than
+        // glob-restricted, which would silently narrow what we invalidate if
+        // Symfony changed its naming.
+        return array_values(array_filter(
             glob($this->paths->storage.'/locale/*') ?: [],
             fn (string $file) => str_ends_with($file, '.php')
-        );
+        ));
+    }
 
-        $this->locales->clearCache();
-
+    /**
+     * Invalidate the OPcache entry of each compiled catalogue in this SAPI.
+     *
+     * Belt-and-braces: Symfony re-invalidates a catalogue when it rewrites
+     * one, and from the CLI subscriber this is a no-op (opcache.enable_cli is
+     * off by default). It replaces an earlier global opcache_reset(), which
+     * forced the whole php-fpm pool to recompile everything mid-traffic — far
+     * more disruptive than the staleness it guarded against.
+     *
+     * @param list<string> $files
+     */
+    protected function invalidateOpcache(array $files): void
+    {
         if (!function_exists('opcache_invalidate')) {
             return;
         }

--- a/tests/integration/PubSubCacheInvalidationTest.php
+++ b/tests/integration/PubSubCacheInvalidationTest.php
@@ -166,11 +166,7 @@ class PubSubCacheInvalidationTest extends TestCase
         $catalogue = $paths->storage.'/locale/catalogue.en.sentinel.php';
         file_put_contents($catalogue, '<?php return [];');
 
-        $invalidator = new class(
-            $container,
-            $paths,
-            $container->make(LocaleManager::class)
-        ) extends LocalCacheInvalidator {
+        $invalidator = new class($container, $paths, $container->make(LocaleManager::class)) extends LocalCacheInvalidator {
             /** @var list<string> */
             public array $invalidated = [];
 

--- a/tests/integration/PubSubCacheInvalidationTest.php
+++ b/tests/integration/PubSubCacheInvalidationTest.php
@@ -18,6 +18,7 @@ use Flarum\Extension\Event\Enabled;
 use Flarum\Extension\Extension;
 use Flarum\Foundation\Event\ClearingCache;
 use Flarum\Foundation\Paths;
+use Flarum\Locale\LocaleManager;
 use Flarum\Settings\Event\Saved;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Testing\integration\TestCase;
@@ -139,6 +140,54 @@ class PubSubCacheInvalidationTest extends TestCase
             $container->make('flarum.api_client.exclude_middleware'),
             'Internal API sub-requests must not re-run the epoch check'
         );
+    }
+
+    /**
+     * The catalogues are deleted by core, from markDirty() — this extension no
+     * longer deletes them itself, because since core 2.0 a catalogue carries a
+     * `.revision` sidecar that CatalogueCache compares per request, so a pod
+     * that never received a message detects staleness on its own.
+     *
+     * What core does not do is tell OPcache, and a catalogue is a PHP file
+     * Symfony rewrites at the same path. So the file list must still be
+     * captured before the deletion and handed to the OPcache pass — this is
+     * what asserts that ordering, which the apply test above cannot: it passes
+     * whether the deletion came from core or from here.
+     */
+    #[Test]
+    public function the_opcache_pass_sees_the_catalogues_captured_before_core_deleted_them()
+    {
+        $container = $this->app()->getContainer();
+
+        /** @var Paths $paths */
+        $paths = $container->make(Paths::class);
+
+        @mkdir($paths->storage.'/locale', 0777, true);
+        $catalogue = $paths->storage.'/locale/catalogue.en.sentinel.php';
+        file_put_contents($catalogue, '<?php return [];');
+
+        $invalidator = new class(
+            $container,
+            $paths,
+            $container->make(LocaleManager::class)
+        ) extends LocalCacheInvalidator {
+            /** @var list<string> */
+            public array $invalidated = [];
+
+            protected function invalidateOpcache(array $files): void
+            {
+                $this->invalidated = $files;
+            }
+        };
+
+        $invalidator->invalidate();
+
+        $this->assertContains(
+            $catalogue,
+            $invalidator->invalidated,
+            'The list captured before the deletion must reach the OPcache pass, or nothing is invalidated'
+        );
+        $this->assertFileDoesNotExist($catalogue, 'Core deletes the catalogue via markDirty()');
     }
 
     #[Test]


### PR DESCRIPTION
**Changes proposed in this pull request:**

`LocalCacheInvalidator::invalidate()` deleted the compiled locale catalogues itself, then called `markAssetsDirty()` — which calls core's `RecompileFrontendAssets::markDirty()`, which calls `LocaleManager::clearCache()` and deletes them again. The double deletion has been there since the apply was written; the second is a no-op on an already-empty directory, but the first is the one that shaped the code around it.

The old comment justified keeping it on the grounds that *"nothing detects staleness and deletion is the only way to force a rebuild from the YAML sources"*. That was true when written. It isn't now: core 2.0 writes a `.revision` sidecar beside each catalogue and `CatalogueCache::isFresh()` compares it per request per locale, so an instance that never received an invalidation message works out for itself that its catalogue is stale (flarum/framework#5046).

So the deletion is core's job. What core does **not** do is tell OPcache, and a catalogue is a PHP file Symfony rewrites at the same path — a cached entry can shadow the new contents in this SAPI until the timestamp is re-checked. That part stays.

`clearLocaleCatalogues()` is therefore split:

- `localeCatalogues()` — captures the file list, which still has to happen *before* core unlinks them, since OPcache entries are keyed by path.
- `invalidateOpcache()` — runs after `markAssetsDirty()`, on that captured list.

No behaviour change in the normal path: the catalogues are still deleted, the OPcache entries are still invalidated, in the same order relative to each other.

**Reviewers should focus on:**

- **The ordering is the whole change, and the existing apply test can't catch it.** `middleware_applies_newer_epoch_and_clears_local_caches` asserts the catalogue is gone afterwards, which passes whether core or this extension deleted it — so it would stay green if the capture moved after the deletion and the OPcache pass silently received an empty list. Added `the_opcache_pass_sees_the_catalogues_captured_before_core_deleted_them`, which substitutes `invalidateOpcache()` and asserts the file reaches it.
- **This narrows one failure mode on rc.8.** `CatalogueCache` isn't in rc.8, so there the deletion really is the only thing forcing a rebuild. `markAssetsDirty()` swallows and logs a `\Throwable`, and previously our own deletion had already run by that point. Now a failure there leaves the catalogues in place, and that pod serves stale translations until the next admin action. It needs a container that can't resolve `AssetManager` or the settings repository, and 2.0.0 makes it moot — flagging it rather than hiding it.
- The `require` is on `2.x-dev` for now, to be changed when 2.0.0 is tagged.

**Confirmed**

- [x] Backend changes: tests are green (`composer test`).
- [x] Backend changes: tests have been added.

---

Tested on both cores, from published packages rather than a path symlink:

| core | unit | integration (real Redis + MySQL) |
|---|---|---|
| v2.0.0-rc.8 | 15/15 | 70/70 |
| 2.x-dev `d8f4824` (= the flarum/framework#5049 merge) | 15/15 | 70/70 |
